### PR TITLE
Correct server url sanitation

### DIFF
--- a/Assets/Plugins/CountlySDK/Countly.cs
+++ b/Assets/Plugins/CountlySDK/Countly.cs
@@ -112,7 +112,17 @@ namespace Plugins.CountlySDK
             {
                 transform.parent = configuration.Parent.transform;
             }
-            
+
+            if (string.IsNullOrEmpty(configuration.ServerUrl))
+                throw new ArgumentNullException(configuration.ServerUrl, "Server URL is required.");
+            if (string.IsNullOrEmpty(configuration.AppKey))
+                throw new ArgumentNullException(configuration.AppKey, "App Key is required.");
+
+            if (configuration.ServerUrl[configuration.ServerUrl.Length - 1] == '/')
+            {
+                configuration.ServerUrl = configuration.ServerUrl.Remove(configuration.ServerUrl.Length - 1);
+            }
+
             Configuration = configuration;
 
             _db = CountlyBoxDbHelper.BuildDatabase(DbNumber);

--- a/Assets/Plugins/CountlySDK/CountlyUtils.cs
+++ b/Assets/Plugins/CountlySDK/CountlyUtils.cs
@@ -42,11 +42,13 @@ namespace Plugins.CountlySDK
         /// <returns></returns>
         public string GetBaseInputUrl()
         {
-            return string.Format(
-                _countly.Initialization.ServerUrl[_countly.Initialization.ServerUrl.Length - 1] == '/'
-                    ? "{0}i?"
-                    : "{0}/i?",
-                _countly.Initialization.ServerUrl);
+            string url = _countly.Initialization.ServerUrl;
+            if (url[url.Length - 1] == '/')
+            {
+                url = url.Remove(url.Length - 1);
+            }
+
+            return url + "/i?";
         }
 
         /// <summary>
@@ -55,11 +57,14 @@ namespace Plugins.CountlySDK
         /// <returns></returns>
         public string GetBaseOutputUrl()
         {
-            return string.Format(
-                _countly.Initialization.ServerUrl[_countly.Initialization.ServerUrl.Length - 1] == '/'
-                    ? "{0}o?"
-                    : "{0}/o?",
-                _countly.Initialization.ServerUrl);
+
+            string url = _countly.Initialization.ServerUrl;
+            if (url[url.Length - 1] == '/')
+            {
+                url = url.Remove(url.Length - 1);
+            }
+
+            return url + "/o?";
         }
 
         /// <summary>
@@ -68,11 +73,13 @@ namespace Plugins.CountlySDK
         /// <returns></returns>
         public string GetRemoteConfigOutputUrl()
         {
-            return string.Format(
-                _countly.Initialization.ServerUrl[_countly.Initialization.ServerUrl.Length - 1] == '/'
-                    ? "{0}o/sdk?"
-                    : "{0}/o/sdk?",
-                _countly.Initialization.ServerUrl);
+            string url = _countly.Initialization.ServerUrl;
+            if (url[url.Length - 1] == '/')
+            {
+                url = url.Remove(url.Length - 1);
+            }
+
+            return url + "/o/sdk?";
         }
 
         /// <summary>

--- a/Assets/Plugins/CountlySDK/CountlyUtils.cs
+++ b/Assets/Plugins/CountlySDK/CountlyUtils.cs
@@ -12,19 +12,16 @@ namespace Plugins.CountlySDK
 
         private readonly Countly _countly;
 
-        internal string InputUrl { get; private set; }
+        internal string ServerInputUrl { get; private set; }
 
-        internal string OutputUrl { get; private set; }
-
-        internal string ConfigUrl { get; private set; }
+        internal string ServerOutputUrl { get; private set; }
 
         public CountlyUtils(Countly countly)
         {
             _countly = countly;
 
-            InputUrl = _countly.Initialization.ServerUrl + "/i?";
-            OutputUrl = _countly.Initialization.ServerUrl + "/o?";
-            ConfigUrl = _countly.Initialization.ServerUrl + "/o/sdk?";
+            ServerInputUrl = _countly.Initialization.ServerUrl + "/i?";
+            ServerOutputUrl = _countly.Initialization.ServerUrl + "/o/sdk?";
         }
 
         public string GetUniqueDeviceId()

--- a/Assets/Plugins/CountlySDK/CountlyUtils.cs
+++ b/Assets/Plugins/CountlySDK/CountlyUtils.cs
@@ -22,9 +22,9 @@ namespace Plugins.CountlySDK
         {
             _countly = countly;
 
-            InputUrl = GetBaseInputUrl();
-            OutputUrl = GetBaseOutputUrl();
-            ConfigUrl = GetRemoteConfigOutputUrl();
+            InputUrl = _countly.Initialization.ServerUrl + "/i?";
+            OutputUrl = _countly.Initialization.ServerUrl + "/o?";
+            ConfigUrl = _countly.Initialization.ServerUrl + "/o/sdk?";
         }
 
         public string GetUniqueDeviceId()
@@ -34,52 +34,6 @@ namespace Plugins.CountlySDK
 #else
             return UnityEngine.SystemInfo.deviceUniqueIdentifier;
 #endif
-        }
-
-        /// <summary>
-        ///     Gets the base url to make requests to the Countly server.
-        /// </summary>
-        /// <returns></returns>
-        public string GetBaseInputUrl()
-        {
-            string url = _countly.Initialization.ServerUrl;
-            if (url[url.Length - 1] == '/')
-            {
-                url = url.Remove(url.Length - 1);
-            }
-
-            return url + "/i?";
-        }
-
-        /// <summary>
-        ///     Gets the base url to make remote configrequests to the Countly server.
-        /// </summary>
-        /// <returns></returns>
-        public string GetBaseOutputUrl()
-        {
-
-            string url = _countly.Initialization.ServerUrl;
-            if (url[url.Length - 1] == '/')
-            {
-                url = url.Remove(url.Length - 1);
-            }
-
-            return url + "/o?";
-        }
-
-        /// <summary>
-        ///     Gets the base url to make remote configrequests to the Countly server.
-        /// </summary>
-        /// <returns></returns>
-        public string GetRemoteConfigOutputUrl()
-        {
-            string url = _countly.Initialization.ServerUrl;
-            if (url[url.Length - 1] == '/')
-            {
-                url = url.Remove(url.Length - 1);
-            }
-
-            return url + "/o/sdk?";
         }
 
         /// <summary>

--- a/Assets/Plugins/CountlySDK/CountlyUtils.cs
+++ b/Assets/Plugins/CountlySDK/CountlyUtils.cs
@@ -12,9 +12,19 @@ namespace Plugins.CountlySDK
 
         private readonly Countly _countly;
 
+        internal string InputUrl { get; private set; }
+
+        internal string OutputUrl { get; private set; }
+
+        internal string ConfigUrl { get; private set; }
+
         public CountlyUtils(Countly countly)
         {
             _countly = countly;
+
+            InputUrl = GetBaseInputUrl();
+            OutputUrl = GetBaseOutputUrl();
+            ConfigUrl = GetRemoteConfigOutputUrl();
         }
 
         public string GetUniqueDeviceId()

--- a/Assets/Plugins/CountlySDK/Helpers/RequestCountlyHelper.cs
+++ b/Assets/Plugins/CountlySDK/Helpers/RequestCountlyHelper.cs
@@ -131,12 +131,12 @@ namespace Plugins.CountlySDK.Helpers
                 using (var sha256Hash = SHA256.Create())
                 {
                     var data = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(requestStringBuilder + _config.Salt));
-                    requestStringBuilder.Insert(0, _countlyUtils.GetBaseInputUrl());
+                    requestStringBuilder.Insert(0, _countlyUtils.InputUrl);
                     return requestStringBuilder.AppendFormat("&checksum256={0}", _countlyUtils.GetStringFromBytes(data)).ToString();
                 }
             }
 
-            requestStringBuilder.Insert(0, _countlyUtils.GetBaseInputUrl());
+            requestStringBuilder.Insert(0, _countlyUtils.InputUrl);
             return requestStringBuilder.ToString();
         }
 
@@ -181,7 +181,7 @@ namespace Plugins.CountlySDK.Helpers
             var data = BuildPostRequest(queryParams);
             if (_config.EnablePost || data.Length > 1800)
             {
-                requestModel = new CountlyRequestModel(false, _countlyUtils.GetBaseInputUrl(), BuildPostRequest(queryParams), DateTime.UtcNow);
+                requestModel = new CountlyRequestModel(false, _countlyUtils.InputUrl, BuildPostRequest(queryParams), DateTime.UtcNow);
             }
             else
             {

--- a/Assets/Plugins/CountlySDK/Helpers/RequestCountlyHelper.cs
+++ b/Assets/Plugins/CountlySDK/Helpers/RequestCountlyHelper.cs
@@ -131,12 +131,12 @@ namespace Plugins.CountlySDK.Helpers
                 using (var sha256Hash = SHA256.Create())
                 {
                     var data = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(requestStringBuilder + _config.Salt));
-                    requestStringBuilder.Insert(0, _countlyUtils.InputUrl);
+                    requestStringBuilder.Insert(0, _countlyUtils.ServerInputUrl);
                     return requestStringBuilder.AppendFormat("&checksum256={0}", _countlyUtils.GetStringFromBytes(data)).ToString();
                 }
             }
 
-            requestStringBuilder.Insert(0, _countlyUtils.InputUrl);
+            requestStringBuilder.Insert(0, _countlyUtils.ServerInputUrl);
             return requestStringBuilder.ToString();
         }
 
@@ -181,7 +181,7 @@ namespace Plugins.CountlySDK.Helpers
             var data = BuildPostRequest(queryParams);
             if (_config.EnablePost || data.Length > 1800)
             {
-                requestModel = new CountlyRequestModel(false, _countlyUtils.InputUrl, BuildPostRequest(queryParams), DateTime.UtcNow);
+                requestModel = new CountlyRequestModel(false, _countlyUtils.ServerInputUrl, BuildPostRequest(queryParams), DateTime.UtcNow);
             }
             else
             {

--- a/Assets/Plugins/CountlySDK/Services/InitializationCountlyService.cs
+++ b/Assets/Plugins/CountlySDK/Services/InitializationCountlyService.cs
@@ -25,16 +25,18 @@ namespace Plugins.CountlySDK.Services
         /// <param name="deviceId"></param>
         internal void Begin(string serverUrl, string appKey)
         {
-            ServerUrl = serverUrl;
             AppKey = appKey;
+            ServerUrl = serverUrl;
 
             if (string.IsNullOrEmpty(ServerUrl))
                 throw new ArgumentNullException(serverUrl, "Server URL is required.");
             if (string.IsNullOrEmpty(AppKey))
                 throw new ArgumentNullException(appKey, "App Key is required.");
 
-
-            //ConsentGranted = consentGranted;
+            if (ServerUrl[ServerUrl.Length - 1] == '/')
+            {
+                ServerUrl = ServerUrl.Remove(ServerUrl.Length - 1);
+            }
         }
 
         /// <summary>

--- a/Assets/Plugins/CountlySDK/Services/InitializationCountlyService.cs
+++ b/Assets/Plugins/CountlySDK/Services/InitializationCountlyService.cs
@@ -27,16 +27,6 @@ namespace Plugins.CountlySDK.Services
         {
             AppKey = appKey;
             ServerUrl = serverUrl;
-
-            if (string.IsNullOrEmpty(ServerUrl))
-                throw new ArgumentNullException(serverUrl, "Server URL is required.");
-            if (string.IsNullOrEmpty(AppKey))
-                throw new ArgumentNullException(appKey, "App Key is required.");
-
-            if (ServerUrl[ServerUrl.Length - 1] == '/')
-            {
-                ServerUrl = ServerUrl.Remove(ServerUrl.Length - 1);
-            }
         }
 
         /// <summary>

--- a/Assets/Plugins/CountlySDK/Services/RemoteConfigCountlyService.cs
+++ b/Assets/Plugins/CountlySDK/Services/RemoteConfigCountlyService.cs
@@ -134,7 +134,7 @@ namespace Plugins.CountlySDK.Services
 //                }
 //            }
       
-            _requestStringBuilder.Insert(0, _countlyUtils.GetRemoteConfigOutputUrl());
+            _requestStringBuilder.Insert(0, _countlyUtils.ConfigUrl);
             return _requestStringBuilder.ToString();
         }
 

--- a/Assets/Plugins/CountlySDK/Services/RemoteConfigCountlyService.cs
+++ b/Assets/Plugins/CountlySDK/Services/RemoteConfigCountlyService.cs
@@ -134,7 +134,7 @@ namespace Plugins.CountlySDK.Services
 //                }
 //            }
       
-            _requestStringBuilder.Insert(0, _countlyUtils.ConfigUrl);
+            _requestStringBuilder.Insert(0, _countlyUtils.ServerOutputUrl);
             return _requestStringBuilder.ToString();
         }
 


### PR DESCRIPTION
When a server url is provided, it should be "cleaned up" once during init.  That means the removal of the backslash at the end if it was added.