### PR TITLE
[sdk-169] Correct server url sanitation

### DIFF
--- a/Assets/Plugins/CountlySDK/Countly.cs
+++ b/Assets/Plugins/CountlySDK/Countly.cs
@@ -22,7 +22,7 @@ namespace Plugins.CountlySDK
 
         public CountlyAuthModel Auth;
         public CountlyConfigModel Config;
-        private CountlyConfiguration Configuration;
+        internal CountlyConfiguration Configuration;
 
         /// <summary>
         /// Check if SDK has been initialized.

--- a/Assets/Plugins/CountlySDK/CountlyUtils.cs
+++ b/Assets/Plugins/CountlySDK/CountlyUtils.cs
@@ -20,8 +20,8 @@ namespace Plugins.CountlySDK
         {
             _countly = countly;
 
-            ServerInputUrl = _countly.Initialization.ServerUrl + "/i?";
-            ServerOutputUrl = _countly.Initialization.ServerUrl + "/o/sdk?";
+            ServerInputUrl = _countly.Configuration.ServerUrl + "/i?";
+            ServerOutputUrl = _countly.Configuration.ServerUrl + "/o/sdk?";
         }
 
         public string GetUniqueDeviceId()
@@ -41,7 +41,7 @@ namespace Plugins.CountlySDK
         {
             var baseParams = new Dictionary<string, object>
             {
-                {"app_key", _countly.Initialization.AppKey},
+                {"app_key", _countly.Configuration.AppKey},
                 {"device_id", _countly.Device.DeviceId},
                 {"sdk_name", Constants.SdkName},
                 {"sdk_version", Constants.SdkVersion}
@@ -68,7 +68,7 @@ namespace Plugins.CountlySDK
         {
             return new Dictionary<string, object>
             {
-                {"app_key", _countly.Initialization.AppKey},
+                {"app_key", _countly.Configuration.AppKey},
                 {"device_id", _countly.Device.DeviceId}
             };
         }


### PR DESCRIPTION
When a server URL is provided, it should be "cleaned up" once during init.  That means the removal of the backslash at the end if it was added.