### PR TITLE
Requested Test Added

### DIFF
--- a/Assets/Plugins/CountlySDK/Helpers/MetricHelper.cs
+++ b/Assets/Plugins/CountlySDK/Helpers/MetricHelper.cs
@@ -6,7 +6,7 @@ namespace Plugins.CountlySDK.Helpers
 {
     public class MetricHelper
     {
-        private Dictionary<string, string> overridenMetrics;
+        internal Dictionary<string, string> overridenMetrics;
         readonly string unityPlatform;
 
         public MetricHelper() : this(null)

--- a/Assets/Plugins/CountlySDK/Models/CountlyConfiguration.cs
+++ b/Assets/Plugins/CountlySDK/Models/CountlyConfiguration.cs
@@ -236,5 +236,10 @@ namespace Plugins.CountlySDK.Models
         {
             NotificationEventListeners.Add(listener);
         }
+
+        public void SetMetricOverride(Dictionary<string, string> overridenMetrics)
+        {
+            this.overridenMetrics = overridenMetrics;
+        }
     }
 }

--- a/Assets/Plugins/CountlySDK/Models/CountlyConfiguration.cs
+++ b/Assets/Plugins/CountlySDK/Models/CountlyConfiguration.cs
@@ -126,19 +126,18 @@ namespace Plugins.CountlySDK.Models
         internal string[] EnabledConsentGroups { get; private set; }
         internal List<INotificationListener> NotificationEventListeners;
         internal Dictionary<string, Consents[]> ConsentGroups { get; private set; }
-
         internal Dictionary<string, string> overridenMetrics;
         internal MetricHelper metricHelper;
 
         /// <summary>
         /// Parent must be undestroyable
         /// </summary>
-        public GameObject Parent = null;        
+        public GameObject Parent = null;
 
         public CountlyConfiguration()
         {
             ConsentGroups = new Dictionary<string, Consents[]>();
-            NotificationEventListeners = new List<INotificationListener>();            
+            NotificationEventListeners = new List<INotificationListener>();
         }
 
         internal CountlyConfiguration(CountlyAuthModel authModel, CountlyConfigModel config)
@@ -236,11 +235,6 @@ namespace Plugins.CountlySDK.Models
         public void AddNotificationListener(INotificationListener listener)
         {
             NotificationEventListeners.Add(listener);
-        }
-        
-        public void SetMetricOverride(Dictionary<string, string> overridenMetrics)
-        {
-            this.overridenMetrics = overridenMetrics;
         }
     }
 }

--- a/Assets/Tests/PlayModeTests/SessionTests.cs
+++ b/Assets/Tests/PlayModeTests/SessionTests.cs
@@ -312,6 +312,9 @@ namespace Tests
             Assert.AreEqual(metricsObject["_locale"].ToString(), config.metricHelper.Locale);
         }
 
+        // Validates the metric override and custom metric functionalities
+        // Overrides metrics in configuration object and compares them with metrics within the request
+        // Metrics within configuration object should be equal to parsed session metrics and overridden ones
         [Test]
         public void SessionMetricOverride()
         {
@@ -327,7 +330,7 @@ namespace Tests
                 { "_locale", "한국인"},
                 { "UserMetric", "user metric"}
             };
-            config.overridenMetrics = overrides;
+            config.SetMetricOverride(overrides);
 
             Countly.Instance.Init(config);
             Assert.IsNotNull(Countly.Instance.Session);

--- a/Assets/Tests/PlayModeTests/SessionTests.cs
+++ b/Assets/Tests/PlayModeTests/SessionTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
 using Plugins.CountlySDK.Models;
@@ -285,7 +285,7 @@ namespace Tests
         }
 
         // Validates the accuracy of the metrics within a request
-        // Parses the metrics within the request and compares with a new 'CountlyMetricModel'
+        // Parses the metrics within the request and compares with 'MetricHelper' in configuration object
         // Metrics within the parsed object should be equal to the expected values.
         [Test]
         public void SessionMetrics()
@@ -310,6 +310,45 @@ namespace Tests
             Assert.AreEqual(metricsObject["_app_version"].ToString(), config.metricHelper.AppVersion);
             Assert.AreEqual(metricsObject["_density"].ToString(), config.metricHelper.Density);
             Assert.AreEqual(metricsObject["_locale"].ToString(), config.metricHelper.Locale);
+        }
+
+        [Test]
+        public void SessionMetricOverride()
+        {
+            CountlyConfiguration config = TestUtility.createBaseConfig();
+            Dictionary<string, string> overrides = new Dictionary<string, string>
+            {
+                { "_os", "New OS" },
+                { "_os_version", "First One" },
+                { "_device", "Smart Fridge"},
+                { "_resolution", "1080p"},
+                { "_app_version","0" },
+                { "_density", "High"},
+                { "_locale", "한국인"},
+                { "UserMetric", "user metric"}
+            };
+            config.overridenMetrics = overrides;
+
+            Countly.Instance.Init(config);
+            Assert.IsNotNull(Countly.Instance.Session);
+            Assert.AreEqual(1, Countly.Instance.Session._requestCountlyHelper._requestRepo.Count);
+
+            CountlyRequestModel requestModel = Countly.Instance.Session._requestCountlyHelper._requestRepo.Dequeue();
+            string[] kvp = requestModel.RequestData.Split('&');
+            string metricsKeyValue = kvp.FirstOrDefault(kv => kv.StartsWith("metrics="));
+            string metricsJsonString = Uri.UnescapeDataString(metricsKeyValue.Substring("metrics=".Length));
+            JObject metricsObject = JObject.Parse(metricsJsonString);
+
+            Dictionary<string, object> configMetrics = Converter.ConvertJsonToDictionary(config.metricHelper.buildMetricJSON(), null);
+
+            Assert.AreEqual(metricsObject["_os"].ToString(), configMetrics["_os"], "New OS");
+            Assert.AreEqual(metricsObject["_os_version"].ToString(), configMetrics["_os_version"], "First One");
+            Assert.AreEqual(metricsObject["_device"].ToString(), configMetrics["_device"], "Smart Fridge");
+            Assert.AreEqual(metricsObject["_resolution"].ToString(), configMetrics["_resolution"], "1080p");
+            Assert.AreEqual(metricsObject["_app_version"].ToString(), configMetrics["_app_version"], "0");
+            Assert.AreEqual(metricsObject["_density"].ToString(), configMetrics["_density"], "High");
+            Assert.AreEqual(metricsObject["_locale"].ToString(), configMetrics["_locale"], "한국인");
+            Assert.AreEqual(metricsObject["UserMetric"].ToString(), configMetrics["UserMetric"], "user metric");
         }
 
         [SetUp]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## XX.X.X
+* Added MetricHelper class and "overriddenMetrics" field in the configuration object, allowing to pass custom or overridden metrics.
+
 ## 23.06.1
 * Added app version metric to every request sent.
 * Fixed a bug that caused build issues when not running inside the editor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## XX.X.X
-* Added MetricHelper class and "overriddenMetrics" field in the configuration object, allowing to pass custom or overridden metrics.
+* Added functionality to allow passing custom or overridden metrics.
 
 ## 23.06.1
 * Added app version metric to every request sent.


### PR DESCRIPTION
Session metric override test added.

Changelog entry for metric override added.

overridenMetrics field in MetricHelper changed into internal, which was causing a compiler error while it was private.