### PR TITLE
Extracted EventTests from EventService PR

### DIFF
--- a/Assets/Tests/PlayModeTests/EventTests.cs
+++ b/Assets/Tests/PlayModeTests/EventTests.cs
@@ -43,12 +43,7 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public void TestEventRepoInitialState()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
@@ -60,12 +55,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventConsent()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true
-            };
-
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
@@ -91,12 +82,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public void TestTimedEventsCancelationOnConsentRemoval()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true
-            };
-
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
@@ -131,12 +118,7 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestTimedEventsCancelationOnDeviceIdChange()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
 
             Countly.Instance.Events.StartEvent("test_event");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -157,12 +139,7 @@ namespace Assets.Tests.PlayModeTests
         [UnityTest]
         public IEnumerator TestTimedEventMethods()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
@@ -211,12 +188,7 @@ namespace Assets.Tests.PlayModeTests
         [UnityTest]
         public IEnumerator TestTimedEventWithSegmentation()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
@@ -245,7 +217,6 @@ namespace Assets.Tests.PlayModeTests
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 10, 5, 2.5, segmentation);
-
         }
 
         /// <summary>
@@ -254,12 +225,7 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAsync()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
@@ -269,13 +235,11 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 0, 1, null, null);
 
-
             await Countly.Instance.Events.RecordEventAsync("test_event1", segmentation: null, count: 5, duration: null, sum: null);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event1", null, 5, null, null);
-
         }
 
         /// <summary>
@@ -284,11 +248,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEvent_EventQueueThreshold_Limit()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                EventQueueThreshold = 3
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetEventQueueSizeToSend(3);
 
             Countly.Instance.Init(configuration);
 
@@ -311,30 +272,18 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_ReportCustomEventAsync()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
 
             Assert.IsNotNull(Countly.Instance.Events);
-
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
-
             Dictionary<string, object> segments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", "value2"}
+                { "key1", "value1"},
+                { "key2", "value2"}
             };
-
             SegmentModel segmentModel = new SegmentModel(segments);
-
             await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segmentModel, sum: 23, duration: 5);
-
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 23, 1, 5, segments);
-
         }
 
         /// <summary>
@@ -343,40 +292,30 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventLimits()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                MaxKeyLength = 4,
-                MaxValueSize = 6,
-                MaxSegmentationValues = 2
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetMaxKeyLength(4)
+                .SetMaxValueSize(6)
+                .SetMaxSegmentationValues(2);
 
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
-
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-
             Dictionary<string, object> segments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2_00", "value2_00"},
-            { "key3_00", "value3"}
+                { "key1", "value1"},
+                { "key2_00", "value2_00"},
+                { "key3_00", "value3"}
             };
 
             SegmentModel segmentModel = new SegmentModel(segments);
-
             await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segmentModel, sum: 23, duration: 5);
-
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
-
             Dictionary<string, object> requireSegments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", "value2"},
+                { "key1", "value1"},
+                { "key2", "value2"},
             };
-
             AssertAnEvent(model, "test", 23, 1, 5, requireSegments);
-
         }
 
         /// <summary>
@@ -385,34 +324,27 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestSegmentItemsDataTypesValidation()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
 
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
             Dictionary<string, object> segments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", 1},
-            { "key3", 10.0},
-            { "key4", true},
-            { "key5", null},// invalid
-            { "key6", Countly.Instance} // invalid
+                { "key1", "value1"},
+                { "key2", 1},
+                { "key3", 10.0},
+                { "key4", true},
+                { "key5", null},// invalid
+                { "key6", Countly.Instance} // invalid
             };
 
             await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segments, sum: 23, duration: 5);
-
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
-
             Dictionary<string, object> requireSegments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", 1},
-            { "key3", 10.0},
-            { "key4", true},
+                { "key1", "value1"},
+                { "key2", 1},
+                { "key3", 10.0},
+                { "key4", true},
             };
 
             AssertAnEvent(model, "test_event", 23, 1, 5, requireSegments);
@@ -424,22 +356,15 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventsParameters()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
 
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-
             Dictionary<string, object> segments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", "value2"}
+                { "key1", "value1"},
+                { "key2", "value2"}
             };
-
 
             await Countly.Instance.Events.RecordEventAsync("", segmentation: segments, sum: 23, duration: 5);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -467,11 +392,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestSpecificKeysConsent()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -501,7 +423,6 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
         }
 
         /// <summary>
@@ -510,17 +431,13 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstViewKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
 
             //[CLY]_view
             Countly.Instance.Consents.GiveConsent(new Consents[] { Consents.Views });
@@ -528,13 +445,11 @@ namespace Assets.Tests.PlayModeTests
             await Countly.Instance.Events.RecordEventAsync("event");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -565,11 +480,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstActionKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -583,7 +495,6 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -606,7 +517,6 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_action", 0, 1, null, null);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_action", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
@@ -620,11 +530,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstStarRatingKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -638,7 +545,6 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -661,13 +567,11 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_star_rating", 0, 1, null, null);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_star_rating", 1, 5, null, null);
-
         }
 
         /// <summary>
@@ -676,11 +580,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstPushActionKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -717,13 +618,11 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_push_action", 0, 1, null, null);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_push_action", 1, 5, null, null);
-
         }
         /// <summary>
         /// It validates 'recordEvent' against push specific key '[CLY]_orientation'.
@@ -731,11 +630,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstOrientationKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -784,11 +680,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAsyncWithSpecificKeys()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -846,19 +739,16 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_nps", 1, 5, null, null);
-
         }
+
         /// <summary>
         /// It validates 'recordEvent' against specific event keys.
         /// </summary>
         [Test]
         public async void TestEventMethod_RecordEventAgainstSpecificEventKeys()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -885,7 +775,6 @@ namespace Assets.Tests.PlayModeTests
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
@@ -905,14 +794,13 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "event", 1, 5, null, null);
-
         }
 
+        [SetUp]
         [TearDown]
         public void End()
         {
-            Countly.Instance.ClearStorage();
-            UnityEngine.Object.DestroyImmediate(Countly.Instance);
+            TestUtility.TestCleanup();
         }
     }
 }

--- a/Assets/Tests/PlayModeTests/EventTests.cs
+++ b/Assets/Tests/PlayModeTests/EventTests.cs
@@ -10,6 +10,9 @@ namespace Assets.Tests.PlayModeTests
 {
     public class EventTests
     {
+        private readonly string _serverUrl = "https://xyz.com/";
+        private readonly string _appKey = "772c091355076ead703f987fee94490";
+
         private void AssertAnEvent(CountlyEventModel model, string name, double? sum, double count, double? duration, IDictionary<string, object> segmentation)
         {
             Assert.AreEqual(name, model.Key);
@@ -40,9 +43,15 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public void TestEventRepoInitialState()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
         }
 
         /// <summary>
@@ -51,8 +60,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventConsent()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -79,8 +91,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public void TestTimedEventsCancelationOnConsentRemoval()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -116,7 +131,12 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestTimedEventsCancelationOnDeviceIdChange()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
 
             Countly.Instance.Events.StartEvent("test_event");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -137,7 +157,12 @@ namespace Assets.Tests.PlayModeTests
         [UnityTest]
         public IEnumerator TestTimedEventMethods()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
@@ -186,7 +211,12 @@ namespace Assets.Tests.PlayModeTests
         [UnityTest]
         public IEnumerator TestTimedEventWithSegmentation()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
@@ -215,6 +245,7 @@ namespace Assets.Tests.PlayModeTests
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 10, 5, 2.5, segmentation);
+
         }
 
         /// <summary>
@@ -223,7 +254,12 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAsync()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
@@ -239,6 +275,7 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event1", null, 5, null, null);
+
         }
 
         /// <summary>
@@ -247,8 +284,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEvent_EventQueueThreshold_Limit()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetEventQueueSizeToSend(3);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                EventQueueThreshold = 3
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -271,13 +311,21 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_ReportCustomEventAsync()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
+
             Assert.IsNotNull(Countly.Instance.Events);
+
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
+
             Dictionary<string, object> segments = new Dictionary<string, object>{
-                { "key1", "value1"},
-                { "key2", "value2"}
+            { "key1", "value1"},
+            { "key2", "value2"}
             };
 
             SegmentModel segmentModel = new SegmentModel(segments);
@@ -286,6 +334,7 @@ namespace Assets.Tests.PlayModeTests
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 23, 1, 5, segments);
+
         }
 
         /// <summary>
@@ -294,27 +343,40 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventLimits()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetMaxKeyLength(4)
-                .SetMaxValueSize(6)
-                .SetMaxSegmentationValues(2);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                MaxKeyLength = 4,
+                MaxValueSize = 6,
+                MaxSegmentationValues = 2
+            };
+
             Countly.Instance.Init(configuration);
+
             Assert.IsNotNull(Countly.Instance.Events);
+
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
+
             Dictionary<string, object> segments = new Dictionary<string, object>{
-                { "key1", "value1"},
-                { "key2_00", "value2_00"},
-                { "key3_00", "value3"}
+            { "key1", "value1"},
+            { "key2_00", "value2_00"},
+            { "key3_00", "value3"}
             };
 
             SegmentModel segmentModel = new SegmentModel(segments);
+
             await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segmentModel, sum: 23, duration: 5);
+
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
+
             Dictionary<string, object> requireSegments = new Dictionary<string, object>{
-                { "key1", "value1"},
-                { "key2", "value2"},
+            { "key1", "value1"},
+            { "key2", "value2"},
             };
+
             AssertAnEvent(model, "test", 23, 1, 5, requireSegments);
+
         }
 
         /// <summary>
@@ -323,25 +385,36 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestSegmentItemsDataTypesValidation()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
+
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
             Dictionary<string, object> segments = new Dictionary<string, object>{
-                { "key1", "value1"},
-                { "key2", 1},
-                { "key3", 10.0},
-                { "key4", true},
-                { "key5", null},// invalid
-                { "key6", Countly.Instance} // invalid
+            { "key1", "value1"},
+            { "key2", 1},
+            { "key3", 10.0},
+            { "key4", true},
+            { "key5", null},// invalid
+            { "key6", Countly.Instance} // invalid
             };
+
             await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segments, sum: 23, duration: 5);
+
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
+
             Dictionary<string, object> requireSegments = new Dictionary<string, object>{
-                { "key1", "value1"},
-                { "key2", 1},
-                { "key3", 10.0},
-                { "key4", true},
+            { "key1", "value1"},
+            { "key2", 1},
+            { "key3", 10.0},
+            { "key4", true},
             };
+
             AssertAnEvent(model, "test_event", 23, 1, 5, requireSegments);
         }
 
@@ -351,15 +424,22 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventsParameters()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
+
             Dictionary<string, object> segments = new Dictionary<string, object>{
-                { "key1", "value1"},
-                { "key2", "value2"}
+            { "key1", "value1"},
+            { "key2", "value2"}
             };
+
 
             await Countly.Instance.Events.RecordEventAsync("", segmentation: segments, sum: 23, duration: 5);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -387,8 +467,12 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestSpecificKeysConsent()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
+
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
@@ -417,6 +501,7 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
         }
 
         /// <summary>
@@ -425,13 +510,17 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstViewKey()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
 
             //[CLY]_view
             Countly.Instance.Consents.GiveConsent(new Consents[] { Consents.Views });
@@ -439,11 +528,13 @@ namespace Assets.Tests.PlayModeTests
             await Countly.Instance.Events.RecordEventAsync("event");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
+
             await Countly.Instance.Events.RecordEventAsync("[CLY]_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -474,8 +565,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstActionKey()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -489,6 +583,7 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -511,6 +606,7 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_action", 0, 1, null, null);
 
+
             await Countly.Instance.Events.RecordEventAsync("[CLY]_action", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
@@ -524,8 +620,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstStarRatingKey()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -539,6 +638,7 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -561,11 +661,13 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_star_rating", 0, 1, null, null);
 
+
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_star_rating", 1, 5, null, null);
+
         }
 
         /// <summary>
@@ -574,8 +676,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstPushActionKey()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -612,21 +717,25 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_push_action", 0, 1, null, null);
 
+
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_push_action", 1, 5, null, null);
-        }
 
+        }
         /// <summary>
         /// It validates 'recordEvent' against push specific key '[CLY]_orientation'.
         /// </summary>
         [Test]
         public async void TestEventMethod_RecordEventAgainstOrientationKey()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -675,8 +784,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAsyncWithSpecificKeys()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -734,16 +846,19 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_nps", 1, 5, null, null);
-        }
 
+        }
         /// <summary>
         /// It validates 'recordEvent' against specific event keys.
         /// </summary>
         [Test]
         public async void TestEventMethod_RecordEventAgainstSpecificEventKeys()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -770,6 +885,7 @@ namespace Assets.Tests.PlayModeTests
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
+
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
@@ -789,9 +905,9 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "event", 1, 5, null, null);
+
         }
 
-        [SetUp]
         [TearDown]
         public void End()
         {

--- a/Assets/Tests/PlayModeTests/EventTests.cs
+++ b/Assets/Tests/PlayModeTests/EventTests.cs
@@ -10,9 +10,6 @@ namespace Assets.Tests.PlayModeTests
 {
     public class EventTests
     {
-        private readonly string _serverUrl = "https://xyz.com/";
-        private readonly string _appKey = "772c091355076ead703f987fee94490";
-
         private void AssertAnEvent(CountlyEventModel model, string name, double? sum, double count, double? duration, IDictionary<string, object> segmentation)
         {
             Assert.AreEqual(name, model.Key);
@@ -43,15 +40,9 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public void TestEventRepoInitialState()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
         }
 
         /// <summary>
@@ -60,11 +51,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventConsent()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -91,11 +79,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public void TestTimedEventsCancelationOnConsentRemoval()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -131,12 +116,7 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestTimedEventsCancelationOnDeviceIdChange()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
 
             Countly.Instance.Events.StartEvent("test_event");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -157,12 +137,7 @@ namespace Assets.Tests.PlayModeTests
         [UnityTest]
         public IEnumerator TestTimedEventMethods()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
@@ -211,12 +186,7 @@ namespace Assets.Tests.PlayModeTests
         [UnityTest]
         public IEnumerator TestTimedEventWithSegmentation()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
@@ -245,7 +215,6 @@ namespace Assets.Tests.PlayModeTests
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 10, 5, 2.5, segmentation);
-
         }
 
         /// <summary>
@@ -254,12 +223,7 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAsync()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
@@ -275,7 +239,6 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event1", null, 5, null, null);
-
         }
 
         /// <summary>
@@ -284,12 +247,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEvent_EventQueueThreshold_Limit()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                EventQueueThreshold = 3
-            };
-
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetEventQueueSizeToSend(3);
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
@@ -311,21 +270,13 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_ReportCustomEventAsync()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
-
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
-
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-
             Dictionary<string, object> segments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", "value2"}
+                { "key1", "value1"},
+                { "key2", "value2"}
             };
 
             SegmentModel segmentModel = new SegmentModel(segments);
@@ -334,7 +285,6 @@ namespace Assets.Tests.PlayModeTests
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 23, 1, 5, segments);
-
         }
 
         /// <summary>
@@ -343,25 +293,18 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventLimits()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                MaxKeyLength = 4,
-                MaxValueSize = 6,
-                MaxSegmentationValues = 2
-            };
-
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetMaxKeyLength(4)
+                .SetMaxValueSize(6)
+                .SetMaxSegmentationValues(2);
             Countly.Instance.Init(configuration);
-
             Assert.IsNotNull(Countly.Instance.Events);
-
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-
             Dictionary<string, object> segments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2_00", "value2_00"},
-            { "key3_00", "value3"}
+                { "key1", "value1"},
+                { "key2_00", "value2_00"},
+                { "key3_00", "value3"}
             };
 
             SegmentModel segmentModel = new SegmentModel(segments);
@@ -371,12 +314,11 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
 
             Dictionary<string, object> requireSegments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", "value2"},
+                { "key1", "value1"},
+                { "key2", "value2"},
             };
 
             AssertAnEvent(model, "test", 23, 1, 5, requireSegments);
-
         }
 
         /// <summary>
@@ -385,23 +327,17 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestSegmentItemsDataTypesValidation()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
-
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
             Dictionary<string, object> segments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", 1},
-            { "key3", 10.0},
-            { "key4", true},
-            { "key5", null},// invalid
-            { "key6", Countly.Instance} // invalid
+                { "key1", "value1"},
+                { "key2", 1},
+                { "key3", 10.0},
+                { "key4", true},
+                { "key5", null},// invalid
+                { "key6", Countly.Instance} // invalid
             };
 
             await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segments, sum: 23, duration: 5);
@@ -409,10 +345,10 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
 
             Dictionary<string, object> requireSegments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", 1},
-            { "key3", 10.0},
-            { "key4", true},
+                { "key1", "value1"},
+                { "key2", 1},
+                { "key3", 10.0},
+                { "key4", true},
             };
 
             AssertAnEvent(model, "test_event", 23, 1, 5, requireSegments);
@@ -424,22 +360,15 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventsParameters()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
 
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-
             Dictionary<string, object> segments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", "value2"}
+                { "key1", "value1"},
+                { "key2", "value2"}
             };
-
 
             await Countly.Instance.Events.RecordEventAsync("", segmentation: segments, sum: 23, duration: 5);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -467,11 +396,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestSpecificKeysConsent()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -501,7 +427,6 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
         }
 
         /// <summary>
@@ -510,17 +435,13 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstViewKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
 
             //[CLY]_view
             Countly.Instance.Consents.GiveConsent(new Consents[] { Consents.Views });
@@ -528,13 +449,11 @@ namespace Assets.Tests.PlayModeTests
             await Countly.Instance.Events.RecordEventAsync("event");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -565,11 +484,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstActionKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -583,7 +499,6 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -606,7 +521,6 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_action", 0, 1, null, null);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_action", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
@@ -620,11 +534,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstStarRatingKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -638,7 +549,6 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -661,13 +571,11 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_star_rating", 0, 1, null, null);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_star_rating", 1, 5, null, null);
-
         }
 
         /// <summary>
@@ -676,11 +584,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstPushActionKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -717,25 +622,21 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_push_action", 0, 1, null, null);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_push_action", 1, 5, null, null);
-
         }
+
         /// <summary>
         /// It validates 'recordEvent' against push specific key '[CLY]_orientation'.
         /// </summary>
         [Test]
         public async void TestEventMethod_RecordEventAgainstOrientationKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -784,11 +685,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAsyncWithSpecificKeys()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -846,19 +744,16 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_nps", 1, 5, null, null);
-
         }
+
         /// <summary>
         /// It validates 'recordEvent' against specific event keys.
         /// </summary>
         [Test]
         public async void TestEventMethod_RecordEventAgainstSpecificEventKeys()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -885,7 +780,6 @@ namespace Assets.Tests.PlayModeTests
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
@@ -905,9 +799,9 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "event", 1, 5, null, null);
-
         }
 
+        [SetUp]
         [TearDown]
         public void End()
         {

--- a/Assets/Tests/PlayModeTests/EventTests.cs
+++ b/Assets/Tests/PlayModeTests/EventTests.cs
@@ -10,9 +10,6 @@ namespace Assets.Tests.PlayModeTests
 {
     public class EventTests
     {
-        private readonly string _serverUrl = "https://xyz.com/";
-        private readonly string _appKey = "772c091355076ead703f987fee94490";
-
         private void AssertAnEvent(CountlyEventModel model, string name, double? sum, double count, double? duration, IDictionary<string, object> segmentation)
         {
             Assert.AreEqual(name, model.Key);
@@ -43,15 +40,9 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public void TestEventRepoInitialState()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
         }
 
         /// <summary>
@@ -60,11 +51,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventConsent()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -91,11 +79,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public void TestTimedEventsCancelationOnConsentRemoval()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -131,12 +116,7 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestTimedEventsCancelationOnDeviceIdChange()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
 
             Countly.Instance.Events.StartEvent("test_event");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -157,12 +137,7 @@ namespace Assets.Tests.PlayModeTests
         [UnityTest]
         public IEnumerator TestTimedEventMethods()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
@@ -211,12 +186,7 @@ namespace Assets.Tests.PlayModeTests
         [UnityTest]
         public IEnumerator TestTimedEventWithSegmentation()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
@@ -245,7 +215,6 @@ namespace Assets.Tests.PlayModeTests
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 10, 5, 2.5, segmentation);
-
         }
 
         /// <summary>
@@ -254,12 +223,7 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAsync()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
@@ -275,7 +239,6 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event1", null, 5, null, null);
-
         }
 
         /// <summary>
@@ -284,11 +247,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEvent_EventQueueThreshold_Limit()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                EventQueueThreshold = 3
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetEventQueueSizeToSend(3);
 
             Countly.Instance.Init(configuration);
 
@@ -311,21 +271,13 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_ReportCustomEventAsync()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
-
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
-
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-
             Dictionary<string, object> segments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", "value2"}
+                { "key1", "value1"},
+                { "key2", "value2"}
             };
 
             SegmentModel segmentModel = new SegmentModel(segments);
@@ -334,7 +286,6 @@ namespace Assets.Tests.PlayModeTests
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 23, 1, 5, segments);
-
         }
 
         /// <summary>
@@ -343,40 +294,27 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventLimits()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                MaxKeyLength = 4,
-                MaxValueSize = 6,
-                MaxSegmentationValues = 2
-            };
-
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetMaxKeyLength(4)
+                .SetMaxValueSize(6)
+                .SetMaxSegmentationValues(2);
             Countly.Instance.Init(configuration);
-
             Assert.IsNotNull(Countly.Instance.Events);
-
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
-
             Dictionary<string, object> segments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2_00", "value2_00"},
-            { "key3_00", "value3"}
+                { "key1", "value1"},
+                { "key2_00", "value2_00"},
+                { "key3_00", "value3"}
             };
 
             SegmentModel segmentModel = new SegmentModel(segments);
-
             await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segmentModel, sum: 23, duration: 5);
-
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
-
             Dictionary<string, object> requireSegments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", "value2"},
+                { "key1", "value1"},
+                { "key2", "value2"},
             };
-
             AssertAnEvent(model, "test", 23, 1, 5, requireSegments);
-
         }
 
         /// <summary>
@@ -385,36 +323,25 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestSegmentItemsDataTypesValidation()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
-
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
             Dictionary<string, object> segments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", 1},
-            { "key3", 10.0},
-            { "key4", true},
-            { "key5", null},// invalid
-            { "key6", Countly.Instance} // invalid
+                { "key1", "value1"},
+                { "key2", 1},
+                { "key3", 10.0},
+                { "key4", true},
+                { "key5", null},// invalid
+                { "key6", Countly.Instance} // invalid
             };
-
             await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segments, sum: 23, duration: 5);
-
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
-
             Dictionary<string, object> requireSegments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", 1},
-            { "key3", 10.0},
-            { "key4", true},
+                { "key1", "value1"},
+                { "key2", 1},
+                { "key3", 10.0},
+                { "key4", true},
             };
-
             AssertAnEvent(model, "test_event", 23, 1, 5, requireSegments);
         }
 
@@ -424,22 +351,15 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventsParameters()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-            };
-
-            Countly.Instance.Init(configuration);
+            Countly.Instance.Init(TestUtility.CreateBaseConfig());
 
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-
             Dictionary<string, object> segments = new Dictionary<string, object>{
-            { "key1", "value1"},
-            { "key2", "value2"}
+                { "key1", "value1"},
+                { "key2", "value2"}
             };
-
 
             await Countly.Instance.Events.RecordEventAsync("", segmentation: segments, sum: 23, duration: 5);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -467,12 +387,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestSpecificKeysConsent()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
-
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
@@ -501,7 +417,6 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
         }
 
         /// <summary>
@@ -510,17 +425,13 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstViewKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
 
             //[CLY]_view
             Countly.Instance.Consents.GiveConsent(new Consents[] { Consents.Views });
@@ -528,13 +439,11 @@ namespace Assets.Tests.PlayModeTests
             await Countly.Instance.Events.RecordEventAsync("event");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -565,11 +474,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstActionKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -583,7 +489,6 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -606,7 +511,6 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_action", 0, 1, null, null);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_action", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
@@ -620,11 +524,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstStarRatingKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -638,7 +539,6 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -661,13 +561,11 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_star_rating", 0, 1, null, null);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_star_rating", 1, 5, null, null);
-
         }
 
         /// <summary>
@@ -676,11 +574,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstPushActionKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -717,25 +612,21 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_push_action", 0, 1, null, null);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_push_action", 1, 5, null, null);
-
         }
+
         /// <summary>
         /// It validates 'recordEvent' against push specific key '[CLY]_orientation'.
         /// </summary>
         [Test]
         public async void TestEventMethod_RecordEventAgainstOrientationKey()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -784,11 +675,8 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAsyncWithSpecificKeys()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -846,19 +734,16 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_nps", 1, 5, null, null);
-
         }
+
         /// <summary>
         /// It validates 'recordEvent' against specific event keys.
         /// </summary>
         [Test]
         public async void TestEventMethod_RecordEventAgainstSpecificEventKeys()
         {
-            CountlyConfiguration configuration = new CountlyConfiguration {
-                ServerUrl = _serverUrl,
-                AppKey = _appKey,
-                RequiresConsent = true,
-            };
+            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
+                .SetRequiresConsent(true);
 
             Countly.Instance.Init(configuration);
 
@@ -885,7 +770,6 @@ namespace Assets.Tests.PlayModeTests
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
@@ -905,9 +789,9 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "event", 1, 5, null, null);
-
         }
 
+        [SetUp]
         [TearDown]
         public void End()
         {

--- a/Assets/Tests/PlayModeTests/EventTests.cs
+++ b/Assets/Tests/PlayModeTests/EventTests.cs
@@ -10,6 +10,9 @@ namespace Assets.Tests.PlayModeTests
 {
     public class EventTests
     {
+        private readonly string _serverUrl = "https://xyz.com/";
+        private readonly string _appKey = "772c091355076ead703f987fee94490";
+
         private void AssertAnEvent(CountlyEventModel model, string name, double? sum, double count, double? duration, IDictionary<string, object> segmentation)
         {
             Assert.AreEqual(name, model.Key);
@@ -40,9 +43,15 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public void TestEventRepoInitialState()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
         }
 
         /// <summary>
@@ -51,8 +60,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventConsent()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -79,8 +91,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public void TestTimedEventsCancelationOnConsentRemoval()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -116,7 +131,12 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestTimedEventsCancelationOnDeviceIdChange()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
 
             Countly.Instance.Events.StartEvent("test_event");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -137,7 +157,12 @@ namespace Assets.Tests.PlayModeTests
         [UnityTest]
         public IEnumerator TestTimedEventMethods()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
@@ -186,7 +211,12 @@ namespace Assets.Tests.PlayModeTests
         [UnityTest]
         public IEnumerator TestTimedEventWithSegmentation()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
@@ -215,6 +245,7 @@ namespace Assets.Tests.PlayModeTests
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 10, 5, 2.5, segmentation);
+
         }
 
         /// <summary>
@@ -223,7 +254,12 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAsync()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
@@ -239,6 +275,7 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event1", null, 5, null, null);
+
         }
 
         /// <summary>
@@ -247,8 +284,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEvent_EventQueueThreshold_Limit()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetEventQueueSizeToSend(3);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                EventQueueThreshold = 3
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -271,13 +311,21 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_ReportCustomEventAsync()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
+
             Assert.IsNotNull(Countly.Instance.Events);
+
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
+
             Dictionary<string, object> segments = new Dictionary<string, object>{
-                { "key1", "value1"},
-                { "key2", "value2"}
+            { "key1", "value1"},
+            { "key2", "value2"}
             };
 
             SegmentModel segmentModel = new SegmentModel(segments);
@@ -286,6 +334,7 @@ namespace Assets.Tests.PlayModeTests
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 23, 1, 5, segments);
+
         }
 
         /// <summary>
@@ -294,27 +343,40 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventLimits()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetMaxKeyLength(4)
-                .SetMaxValueSize(6)
-                .SetMaxSegmentationValues(2);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                MaxKeyLength = 4,
+                MaxValueSize = 6,
+                MaxSegmentationValues = 2
+            };
+
             Countly.Instance.Init(configuration);
+
             Assert.IsNotNull(Countly.Instance.Events);
+
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
+
             Dictionary<string, object> segments = new Dictionary<string, object>{
-                { "key1", "value1"},
-                { "key2_00", "value2_00"},
-                { "key3_00", "value3"}
+            { "key1", "value1"},
+            { "key2_00", "value2_00"},
+            { "key3_00", "value3"}
             };
 
             SegmentModel segmentModel = new SegmentModel(segments);
+
             await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segmentModel, sum: 23, duration: 5);
+
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
+
             Dictionary<string, object> requireSegments = new Dictionary<string, object>{
-                { "key1", "value1"},
-                { "key2", "value2"},
+            { "key1", "value1"},
+            { "key2", "value2"},
             };
+
             AssertAnEvent(model, "test", 23, 1, 5, requireSegments);
+
         }
 
         /// <summary>
@@ -323,25 +385,36 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestSegmentItemsDataTypesValidation()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
+
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
             Dictionary<string, object> segments = new Dictionary<string, object>{
-                { "key1", "value1"},
-                { "key2", 1},
-                { "key3", 10.0},
-                { "key4", true},
-                { "key5", null},// invalid
-                { "key6", Countly.Instance} // invalid
+            { "key1", "value1"},
+            { "key2", 1},
+            { "key3", 10.0},
+            { "key4", true},
+            { "key5", null},// invalid
+            { "key6", Countly.Instance} // invalid
             };
+
             await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segments, sum: 23, duration: 5);
+
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
+
             Dictionary<string, object> requireSegments = new Dictionary<string, object>{
-                { "key1", "value1"},
-                { "key2", 1},
-                { "key3", 10.0},
-                { "key4", true},
+            { "key1", "value1"},
+            { "key2", 1},
+            { "key3", 10.0},
+            { "key4", true},
             };
+
             AssertAnEvent(model, "test_event", 23, 1, 5, requireSegments);
         }
 
@@ -351,15 +424,22 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventsParameters()
         {
-            Countly.Instance.Init(TestUtility.CreateBaseConfig());
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+            };
+
+            Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
+
             Dictionary<string, object> segments = new Dictionary<string, object>{
-                { "key1", "value1"},
-                { "key2", "value2"}
+            { "key1", "value1"},
+            { "key2", "value2"}
             };
+
 
             await Countly.Instance.Events.RecordEventAsync("", segmentation: segments, sum: 23, duration: 5);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -387,8 +467,12 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestSpecificKeysConsent()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
+
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
@@ -417,6 +501,7 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
         }
 
         /// <summary>
@@ -425,13 +510,17 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstViewKey()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
 
             //[CLY]_view
             Countly.Instance.Consents.GiveConsent(new Consents[] { Consents.Views });
@@ -439,11 +528,13 @@ namespace Assets.Tests.PlayModeTests
             await Countly.Instance.Events.RecordEventAsync("event");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
+
             await Countly.Instance.Events.RecordEventAsync("[CLY]_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -474,8 +565,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstActionKey()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -489,6 +583,7 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -511,6 +606,7 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_action", 0, 1, null, null);
 
+
             await Countly.Instance.Events.RecordEventAsync("[CLY]_action", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
@@ -524,8 +620,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstStarRatingKey()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -539,6 +638,7 @@ namespace Assets.Tests.PlayModeTests
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
 
             await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
@@ -561,11 +661,13 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_star_rating", 0, 1, null, null);
 
+
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_star_rating", 1, 5, null, null);
+
         }
 
         /// <summary>
@@ -574,8 +676,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAgainstPushActionKey()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -612,21 +717,25 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_push_action", 0, 1, null, null);
 
+
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action", segmentation: null, count: 5, duration: null, sum: 1);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_push_action", 1, 5, null, null);
-        }
 
+        }
         /// <summary>
         /// It validates 'recordEvent' against push specific key '[CLY]_orientation'.
         /// </summary>
         [Test]
         public async void TestEventMethod_RecordEventAgainstOrientationKey()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -675,8 +784,11 @@ namespace Assets.Tests.PlayModeTests
         [Test]
         public async void TestEventMethod_RecordEventAsyncWithSpecificKeys()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -734,16 +846,19 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_nps", 1, 5, null, null);
-        }
 
+        }
         /// <summary>
         /// It validates 'recordEvent' against specific event keys.
         /// </summary>
         [Test]
         public async void TestEventMethod_RecordEventAgainstSpecificEventKeys()
         {
-            CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
-                .SetRequiresConsent(true);
+            CountlyConfiguration configuration = new CountlyConfiguration {
+                ServerUrl = _serverUrl,
+                AppKey = _appKey,
+                RequiresConsent = true,
+            };
 
             Countly.Instance.Init(configuration);
 
@@ -770,6 +885,7 @@ namespace Assets.Tests.PlayModeTests
             await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
+
             await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
@@ -789,9 +905,10 @@ namespace Assets.Tests.PlayModeTests
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "event", 1, 5, null, null);
+
         }
 
-        [SetUp][TearDown]
+        [TearDown]
         public void End()
         {
             Countly.Instance.ClearStorage();

--- a/Assets/Tests/PlayModeTests/EventTests.cs
+++ b/Assets/Tests/PlayModeTests/EventTests.cs
@@ -10,9 +10,6 @@ namespace Assets.Tests.PlayModeTests
 {
     public class EventTests
     {
-        private readonly string _serverUrl = "https://xyz.com/";
-        private readonly string _appKey = "772c091355076ead703f987fee94490";
-
         private void AssertAnEvent(CountlyEventModel model, string name, double? sum, double count, double? duration, IDictionary<string, object> segmentation)
         {
             Assert.AreEqual(name, model.Key);
@@ -46,7 +43,6 @@ namespace Assets.Tests.PlayModeTests
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
         }
 
         /// <summary>
@@ -57,6 +53,7 @@ namespace Assets.Tests.PlayModeTests
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetRequiresConsent(true);
+
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
@@ -84,6 +81,7 @@ namespace Assets.Tests.PlayModeTests
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetRequiresConsent(true);
+
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
@@ -235,6 +233,7 @@ namespace Assets.Tests.PlayModeTests
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 0, 1, null, null);
 
+
             await Countly.Instance.Events.RecordEventAsync("test_event1", segmentation: null, count: 5, duration: null, sum: null);
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
@@ -273,15 +272,18 @@ namespace Assets.Tests.PlayModeTests
         public async void TestEventMethod_ReportCustomEventAsync()
         {
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
-
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
+
             Dictionary<string, object> segments = new Dictionary<string, object>{
                 { "key1", "value1"},
                 { "key2", "value2"}
             };
+
             SegmentModel segmentModel = new SegmentModel(segments);
+
             await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segmentModel, sum: 23, duration: 5);
+
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 23, 1, 5, segments);
         }
@@ -296,12 +298,9 @@ namespace Assets.Tests.PlayModeTests
                 .SetMaxKeyLength(4)
                 .SetMaxValueSize(6)
                 .SetMaxSegmentationValues(2);
-
             Countly.Instance.Init(configuration);
-
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
             Dictionary<string, object> segments = new Dictionary<string, object>{
                 { "key1", "value1"},
                 { "key2_00", "value2_00"},
@@ -325,10 +324,8 @@ namespace Assets.Tests.PlayModeTests
         public async void TestSegmentItemsDataTypesValidation()
         {
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
-
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
-
             Dictionary<string, object> segments = new Dictionary<string, object>{
                 { "key1", "value1"},
                 { "key2", 1},
@@ -337,7 +334,6 @@ namespace Assets.Tests.PlayModeTests
                 { "key5", null},// invalid
                 { "key6", Countly.Instance} // invalid
             };
-
             await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segments, sum: 23, duration: 5);
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             Dictionary<string, object> requireSegments = new Dictionary<string, object>{
@@ -346,7 +342,6 @@ namespace Assets.Tests.PlayModeTests
                 { "key3", 10.0},
                 { "key4", true},
             };
-
             AssertAnEvent(model, "test_event", 23, 1, 5, requireSegments);
         }
 
@@ -394,7 +389,6 @@ namespace Assets.Tests.PlayModeTests
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetRequiresConsent(true);
-
             Countly.Instance.Init(configuration);
 
             Assert.IsNotNull(Countly.Instance.Events);
@@ -624,6 +618,7 @@ namespace Assets.Tests.PlayModeTests
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_push_action", 1, 5, null, null);
         }
+
         /// <summary>
         /// It validates 'recordEvent' against push specific key '[CLY]_orientation'.
         /// </summary>
@@ -796,11 +791,11 @@ namespace Assets.Tests.PlayModeTests
             AssertAnEvent(model, "event", 1, 5, null, null);
         }
 
-        [SetUp]
-        [TearDown]
+        [SetUp][TearDown]
         public void End()
         {
-            TestUtility.TestCleanup();
+            Countly.Instance.ClearStorage();
+            UnityEngine.Object.DestroyImmediate(Countly.Instance);
         }
     }
 }


### PR DESCRIPTION
Extracted EventTests from EventService PR

Reduced the total length by using the new configuration, which also helps to not print warnings to the console.

Functionality is same and all tests are successful