### PR TITLE
Introduced IViewModule, Deprecated Old Methods

### DIFF
--- a/Assets/Countly/Plugins/CountlySDK/Countly.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Countly.cs
@@ -336,7 +336,7 @@ namespace Plugins.CountlySDK
 
             StarRating = new StarRatingCountlyService(Configuration, _logHelper, Consents, Events);
             UserDetails = new UserDetailsCountlyService(Configuration, _logHelper, RequestHelper, countlyUtils, Consents);
-            Views = new ViewCountlyService(Configuration, _logHelper, Events, Consents);
+            Views = new ViewCountlyService(this, countlyUtils, Configuration, _logHelper, Events, Consents);
             Device = new DeviceIdCountlyService(Configuration, _logHelper, Session, RequestHelper, Events, countlyUtils, Consents);
 
             CreateListOfIBaseService();

--- a/Assets/Countly/Plugins/CountlySDK/Interfaces/IViewModule.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Interfaces/IViewModule.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+// interface for SDK users
+public interface IViewModule
+{
+    /// <summary>
+    /// Start tracking a view
+    /// </summary>
+    /// <param name="name">name of the view</param>
+    /// <returns></returns>
+    [Obsolete("RecordOpenViewAsync(string name, IDictionary<string, object> segmentation = null) is deprecated, this is going to be removed in the future.")]
+    Task RecordOpenViewAsync(string name, IDictionary<string, object> segmentation = null);
+
+    /// <summary>
+    /// Stop tracking a view
+    /// </summary>
+    /// <param name="name of the view"></param>
+    /// <returns></returns>
+    [Obsolete("RecordCloseViewAsync(string name) is deprecated, this is going to be removed in the future.")]
+    Task RecordCloseViewAsync(string name);
+
+    /// <summary>
+    /// Reports a particular action with the specified details
+    /// </summary>
+    /// <param name="type"> type of action</param>
+    /// <param name="x">x-coordinate</param>
+    /// <param name="y">y-coordinate</param>
+    /// <param name="width">width of screen</param>
+    /// <param name="height">height of screen</param>
+    /// <returns></returns>
+    [Obsolete("ReportActionAsync(string type, int x, int y, int width, int height) is deprecated, this is going to be removed in the future.")]
+    Task ReportActionAsync(string type, int x, int y, int width, int height);
+}

--- a/Assets/Countly/Plugins/CountlySDK/Interfaces/IViewModule.cs.meta
+++ b/Assets/Countly/Plugins/CountlySDK/Interfaces/IViewModule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f64177a442064555be12500bf14702a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Extracted IViewModule from the Views PR. 
Deprecated old methods; functionality kept the same to merge easily.