### PR TITLE
Record close view bug fix

### DIFF
--- a/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
@@ -393,12 +393,7 @@ namespace Plugins.CountlySDK.Services
             _utils.TruncateSegmentationValues(customViewSegmentation, _configuration.GetMaxSegmentationValues(), "[ViewCountlyService] StartViewInternal, ", Log);
             _utils.RemoveReservedKeysFromSegmentation(customViewSegmentation, reservedSegmentationKeysViews, "[ViewCountlyService] StartViewInternal, ", Log);
 
-            int segmCount = 0;
-            if (customViewSegmentation != null) {
-                segmCount = customViewSegmentation.Count;
-            }
-
-            Log.Debug("[ViewCountlyService] StartViewInternal, recording view with name: [" + viewName + "], previous view ID:[" + currentViewID + "] custom view segment count:[" + segmCount + "], first:[" + _isFirstView + "], autoStop:[" + viewShouldBeAutomaticallyStopped + "]");
+            Log.Debug("[ViewCountlyService] StartViewInternal, recording view with name: [" + viewName + "], previous view ID:[" + currentViewID + "], custom view segmentation:[" + customViewSegmentation?.ToString() + "], first:[" + _isFirstView + "], autoStop:[" + viewShouldBeAutomaticallyStopped + "]");
 
             AutoCloseRequiredViews(false, null);
 
@@ -795,7 +790,8 @@ namespace Plugins.CountlySDK.Services
         public async Task RecordOpenViewAsync(string name, IDictionary<string, object> segmentation = null)
         {
             lock (LockObj) {
-                StartView(name, (Dictionary<string, object>)segmentation);
+                Log.Info("[ViewCountlyService] RecordOpenViewAsync: name = " + name);
+                StartViewInternal(name, (Dictionary<string, object>)segmentation, false);
             }
             await Task.CompletedTask;
         }
@@ -813,7 +809,8 @@ namespace Plugins.CountlySDK.Services
         public async Task RecordCloseViewAsync(string name)
         {
             lock (LockObj) {
-                StopViewWithName(name);
+                Log.Info("[ViewCountlyService] RecordCloseViewAsync: name = " + name);
+                StopViewWithNameInternal(name, null);
             }
             await Task.CompletedTask;
         }

--- a/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
@@ -390,6 +390,11 @@ namespace Plugins.CountlySDK.Services
                 return null;
             }
 
+            if (viewName.Length > _configuration.GetMaxKeyLength()) {
+                Log.Verbose("[ViewCountlyService] StartViewInternal, max allowed key length is " + _configuration.GetMaxKeyLength());
+                viewName = viewName.Substring(0, _configuration.GetMaxKeyLength());
+            }
+
             _utils.TruncateSegmentationValues(customViewSegmentation, _configuration.GetMaxSegmentationValues(), "[ViewCountlyService] StartViewInternal, ", Log);
             _utils.RemoveReservedKeysFromSegmentation(customViewSegmentation, reservedSegmentationKeysViews, "[ViewCountlyService] StartViewInternal, ", Log);
 
@@ -434,6 +439,11 @@ namespace Plugins.CountlySDK.Services
             if (_utils.IsNullEmptyOrWhitespace(viewName)) {
                 Log.Warning("[ViewCountlyService] StopViewWithNameInternal, trying to record view with null or empty view name, ignoring request");
                 return;
+            }
+
+            if (viewName.Length > _configuration.GetMaxKeyLength()) {
+                Log.Verbose("[ViewCountlyService] StopViewWithNameInternal, max allowed key length is " + _configuration.GetMaxKeyLength());
+                viewName = viewName.Substring(0, _configuration.GetMaxKeyLength());
             }
 
             string viewID = null;

--- a/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
@@ -783,16 +783,22 @@ namespace Plugins.CountlySDK.Services
         /// Do not use with <see cref="StopView"/> as it will not function correctly.
         /// Please use <see cref="StartView"/> and <see cref="StopView"/> for new implementations.
         /// </remarks>
-        /// <param name="viewName">The name of the view to open.</param>
-        /// <param name="viewSegmentation">Optional segmentation data for the view.</param>
+        /// <param name="name">The name of the view to open.</param>
+        /// <param name="segmentation">Optional segmentation data for the view.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         [Obsolete("RecordOpenViewAsync(string name, IDictionary<string, object> segmentation = null) is deprecated and will be removed in the future. Please use StartView instead.")]
         public async Task RecordOpenViewAsync(string name, IDictionary<string, object> segmentation = null)
         {
+            if (!_consentService.CheckConsentInternal(Consents.Views)) {
+                Log.Debug("[ViewCountlyService] RecordOpenViewAsync, consent is not given, ignoring the request.");
+                return;
+            }
+
             lock (LockObj) {
                 Log.Info("[ViewCountlyService] RecordOpenViewAsync: name = " + name);
                 StartViewInternal(name, (Dictionary<string, object>)segmentation, false);
             }
+
             await Task.CompletedTask;
         }
 
@@ -803,15 +809,21 @@ namespace Plugins.CountlySDK.Services
         /// This method should only be used to close views that were opened using <see cref="RecordOpenViewAsync"/>.
         /// Do not use to close views started with <see cref="StartView"/>.
         /// </remarks>
-        /// <param name="viewName">The name of the view to close.</param>
+        /// <param name="name">The name of the view to close.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         [Obsolete("RecordCloseViewAsync(string name) is deprecated and will be removed in the future. Please use StopView instead.")]
         public async Task RecordCloseViewAsync(string name)
         {
+            if (!_consentService.CheckConsentInternal(Consents.Views)) {
+                Log.Debug("[ViewCountlyService] RecordCloseViewAsync, consent is not given, ignoring the request.");
+                return;
+            }
+
             lock (LockObj) {
                 Log.Info("[ViewCountlyService] RecordCloseViewAsync: name = " + name);
                 StopViewWithNameInternal(name, null);
             }
+
             await Task.CompletedTask;
         }
 

--- a/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
@@ -842,6 +842,9 @@ namespace Plugins.CountlySDK.Services
 
                 viewDataMap.Add(currentViewData.ViewID, currentViewData);
 
+                previousViewID = currentViewID;
+                currentViewID = currentViewData.ViewID;
+
                 CountlyEventModel currentView = new CountlyEventModel(viewEventKey, segmentation, 1);
                 _ = _eventService.RecordEventAsync(currentView);
 

--- a/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
@@ -908,7 +908,7 @@ namespace Plugins.CountlySDK.Services
                     {"name", name},
                     {"segment", _configuration.metricHelper.OS},
                 };
-
+                viewDataMap.Remove(viewID);
                 CountlyEventModel currentView = new CountlyEventModel(CountlyEventModel.ViewEvent, segment, 1, null, duration);
                 _ = _eventService.RecordEventAsync(currentView);
             }

--- a/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
@@ -90,7 +90,7 @@ namespace Plugins.CountlySDK.Services
         public string StartView(string viewName, Dictionary<string, object> viewSegmentation)
         {
             lock (LockObj) {
-                Log.Info("[ViewCountlyService] StartView, vn[" + viewName + "] sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (sender, args) => { args.ErrorContext.Handled = true; } })) + "]");
+                Log.Info("[ViewCountlyService] StartView, vn[" + viewName + "] sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (_, args) => { args.ErrorContext.Handled = true; } })) + "]");
                 return StartViewInternal(viewName, viewSegmentation, false);
             }
         }
@@ -121,7 +121,7 @@ namespace Plugins.CountlySDK.Services
         public string StartAutoStoppedView(string viewName, Dictionary<string, object> viewSegmentation)
         {
             lock (LockObj) {
-                Log.Info("[ViewCountlyService] StartAutoStoppedView, vn[" + viewName + "] sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (sender, args) => { args.ErrorContext.Handled = true; } })) + "]");
+                Log.Info("[ViewCountlyService] StartAutoStoppedView, vn[" + viewName + "] sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (_, args) => { args.ErrorContext.Handled = true; } })) + "]");
                 return StartViewInternal(viewName, viewSegmentation, true);
             }
         }

--- a/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
@@ -148,7 +148,7 @@ namespace Plugins.CountlySDK.Services
         public void StopViewWithName(string viewName, Dictionary<string, object> viewSegmentation)
         {
             lock (LockObj) {
-                Log.Info("[ViewCountlyService] StopViewWithName, vn[" + viewName + "] sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (sender, args) => { args.ErrorContext.Handled = true; } })) + "]");
+                Log.Info("[ViewCountlyService] StopViewWithName, vn[" + viewName + "] sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (_, args) => { args.ErrorContext.Handled = true; } })) + "]");
                 StopViewWithNameInternal(viewName, viewSegmentation);
             }
         }
@@ -173,7 +173,7 @@ namespace Plugins.CountlySDK.Services
         public void StopViewWithID(string viewID, Dictionary<string, object> viewSegmentation)
         {
             lock (LockObj) {
-                Log.Info("[ViewCountlyService] StopViewWithID, vi[" + viewID + "] sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (sender, args) => { args.ErrorContext.Handled = true; } })) + "]");
+                Log.Info("[ViewCountlyService] StopViewWithID, vi[" + viewID + "] sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (_, args) => { args.ErrorContext.Handled = true; } })) + "]");
                 StopViewWithIDInternal(viewID, viewSegmentation);
             }
         }
@@ -209,7 +209,7 @@ namespace Plugins.CountlySDK.Services
         public void StopAllViews(Dictionary<string, object> viewSegmentation)
         {
             lock (LockObj) {
-                Log.Info("[ViewCountlyService] StopAllViews, sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (sender, args) => { args.ErrorContext.Handled = true; } })) + "]");
+                Log.Info("[ViewCountlyService] StopAllViews, sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (_, args) => { args.ErrorContext.Handled = true; } })) + "]");
                 StopAllViewsInternal(viewSegmentation);
             }
         }
@@ -221,7 +221,7 @@ namespace Plugins.CountlySDK.Services
         public void SetGlobalViewSegmentation(Dictionary<string, object> viewSegmentation)
         {
             lock (LockObj) {
-                Log.Info("[ViewCountlyService] SetGlobalViewSegmentation, sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (sender, args) => { args.ErrorContext.Handled = true; } })) + "]");
+                Log.Info("[ViewCountlyService] SetGlobalViewSegmentation, sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (_, args) => { args.ErrorContext.Handled = true; } })) + "]");
                 SetGlobalViewSegmentationInternal(viewSegmentation);
             }
         }
@@ -260,7 +260,7 @@ namespace Plugins.CountlySDK.Services
         public void UpdateGlobalViewSegmentation(Dictionary<string, object> viewSegmentation)
         {
             lock (LockObj) {
-                Log.Info("[ViewCountlyService] UpdateGlobalViewSegmentation, sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (sender, args) => { args.ErrorContext.Handled = true; } })) + "]");
+                Log.Info("[ViewCountlyService] UpdateGlobalViewSegmentation, sg[" + (viewSegmentation == null ? "null" : JsonConvert.SerializeObject(viewSegmentation, new JsonSerializerSettings { Error = (_, args) => { args.ErrorContext.Handled = true; } })) + "]");
                 UpdateGlobalViewSegmentationInternal(viewSegmentation);
             }
         }

--- a/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Services/ViewCountlyService.cs
@@ -45,7 +45,7 @@ namespace Plugins.CountlySDK.Services
             _utils = utils;
             eventService.viewIDProvider = this;
             _eventService = eventService;
-            safeViewIDGenerator = configuration.SafeViewIDGenerator; 
+            safeViewIDGenerator = configuration.SafeViewIDGenerator;
         }
 
         #region PublicAPI

--- a/Assets/Tests/PlayModeTests/StarRatingTests.cs
+++ b/Assets/Tests/PlayModeTests/StarRatingTests.cs
@@ -204,8 +204,8 @@ namespace Assets.Tests.PlayModeTests
             Assert.IsNotNull(Countly.Instance.StarRating);
             Assert.AreEqual(0, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
-            await Countly.Instance.Views.RecordCloseViewAsync("close_view");
-            Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
+            Countly.Instance.Views.StartView("view");
+            Assert.AreEqual(1, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
             await Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 4);
             Assert.AreEqual(2, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);

--- a/Assets/Tests/PlayModeTests/ViewsTests.cs
+++ b/Assets/Tests/PlayModeTests/ViewsTests.cs
@@ -132,17 +132,21 @@ namespace Assets.Tests.PlayModeTests
             IViewModule views = cly.Views;
             TestUtility.ValidateRQEQSize(cly, 2, 0);
 
-            Dictionary<string, object> segmentations = new Dictionary<string, object> {
+            Dictionary<string, object> providedSegmentations = new Dictionary<string, object> {
                 { "key1", "value1" },
                 { "key2", null }, // invalid value
                 { "key3", "" }, // invalid value
                 { "key4", new object() }, // invalid value
             };
 
-            await Countly.Instance.Views.RecordOpenViewAsync("open_view", segmentations);
+            Dictionary<string, object> expectedSegmentations = new Dictionary<string, object> {
+                { "key1", "value1" },
+            };
+
+            await Countly.Instance.Views.RecordOpenViewAsync("open_view", providedSegmentations);
             TestUtility.ValidateRQEQSize(cly, 2, 1);
             CountlyEventModel model = cly.Events._eventRepo.Dequeue();
-            TestUtility.ViewEventValidator(model, 1, 0, null, segmentations, "idv1", "", null, null, TestUtility.TestTimeMetrics());
+            TestUtility.ViewEventValidator(model, 1, 0, null, expectedSegmentations, "idv1", "", null, null, TestUtility.TestTimeMetrics());
 
             Assert.AreEqual("value1", model.Segmentation["key1"]);
             Assert.IsFalse(model.Segmentation.ContainsKey("key2"));

--- a/Assets/Tests/PlayModeTests/ViewsTests.cs
+++ b/Assets/Tests/PlayModeTests/ViewsTests.cs
@@ -66,21 +66,18 @@ namespace Assets.Tests.PlayModeTests
 
             await views.RecordOpenViewAsync("open_view");
             await views.RecordCloseViewAsync("close_view");
-            TestUtility.ValidateRQEQSize(cly, 2, 2);
+            TestUtility.ValidateRQEQSize(cly, 2, 1);
 
             CountlyEventModel model = cly.Events._eventRepo.Dequeue();
             TestUtility.ViewEventValidator(model, 1, null, null, TestUtility.BaseViewTestSegmentation("open_", true, true), null, null, null, null, TestUtility.TestTimeMetrics());
-
-            model = cly.Events._eventRepo.Dequeue();
-            TestUtility.ViewEventValidator(model, 1, null, null, TestUtility.BaseViewTestSegmentation("close", false, false), null, null, null, null, TestUtility.TestTimeMetrics());
             TestUtility.ValidateRQEQSize(cly, 2, 0);
         }
 
         // 'RecordCloseViewAsync' method in ViewCountlyService.
-        // We close a view. Verify that the event is correctly recorded in the Views repository
-        // If a valid view name is provided, it should be recorded and EventModel should be validated
+        // We try to close a view that's not existing
+        // If view does not exist nothing should be recorded, nothing should crash
         [Test]
-        public async void RecordCloseViewAsync()
+        public async void RecordCloseViewAsync_NoOpenView()
         {
             CountlyConfiguration config = TestUtility.CreateViewConfig(new CustomIdProvider());
             Countly cly = Countly.Instance;
@@ -89,10 +86,6 @@ namespace Assets.Tests.PlayModeTests
             TestUtility.ValidateRQEQSize(cly, 2, 0);
 
             await views.RecordCloseViewAsync("close_view");
-            TestUtility.ValidateRQEQSize(cly, 2, 1);
-
-            CountlyEventModel model = cly.Events._eventRepo.Dequeue();
-            TestUtility.ViewEventValidator(model, 1, null, null, TestUtility.BaseViewTestSegmentation("close_view", false, false), null, null, null, null, TestUtility.TestTimeMetrics());
             TestUtility.ValidateRQEQSize(cly, 2, 0);
         }
 
@@ -128,12 +121,10 @@ namespace Assets.Tests.PlayModeTests
 
             await views.RecordOpenViewAsync("open_view");
             await views.RecordCloseViewAsync("open_view_2");
-            TestUtility.ValidateRQEQSize(cly, 2, 2);
+            TestUtility.ValidateRQEQSize(cly, 2, 1);
 
             CountlyEventModel model = cly.Events._eventRepo.Dequeue();
             TestUtility.ViewEventValidator(model, 1, null, null, TestUtility.BaseViewTestSegmentation("open_view", true, true), null, null, null, null, TestUtility.TestTimeMetrics());
-            model = cly.Events._eventRepo.Dequeue();
-            TestUtility.ViewEventValidator(model, 1, null, null, TestUtility.BaseViewTestSegmentation("open_view_2", false, false), null, null, null, null, TestUtility.TestTimeMetrics());
         }
 
         // 'RecordOpenViewAsync' method in ViewCountlyService.
@@ -804,7 +795,7 @@ namespace Assets.Tests.PlayModeTests
             string viewId2 = views.StartView(viewNames[0]);
             TestUtility.ValidateRQEQSize(cly, 2, 1);
             CountlyEventModel result2 = cly.Events._eventRepo.Dequeue();
-            TestUtility.ViewEventValidator(result2, 1, 0, null, TestUtility.BaseViewTestSegmentation(viewNames[0], false, false), viewId2, viewId1  , null, null, TestUtility.TestTimeMetrics());
+            TestUtility.ViewEventValidator(result2, 1, 0, null, TestUtility.BaseViewTestSegmentation(viewNames[0], false, false), viewId2, viewId1, null, null, TestUtility.TestTimeMetrics());
 
             string viewId3 = views.StartView(viewNames[0]);
             TestUtility.ValidateRQEQSize(cly, 2, 1);

--- a/Assets/Tests/PlayModeTests/ViewsTests.cs
+++ b/Assets/Tests/PlayModeTests/ViewsTests.cs
@@ -50,29 +50,6 @@ namespace Assets.Tests.PlayModeTests
             TestUtility.ValidateRQEQSize(cly, 2, 0);
         }
 
-        // 'RecordOpenViewAsync' method in ViewCountlyService
-        // We validate the limit of the view's name size with configuring MaxKeyLength.
-        // View Name length should be equal to the "MaxKeyLength"
-        [Test]
-        public async void ViewNameLimit()
-        {
-            CountlyConfiguration config = TestUtility.CreateViewConfig(new CustomIdProvider())
-                .SetMaxKeyLength(5);
-            Countly cly = Countly.Instance;
-
-            cly.Init(config);
-            IViewModule views = cly.Views;
-            TestUtility.ValidateRQEQSize(cly, 2, 0);
-
-            await views.RecordOpenViewAsync("open_view");
-            await views.RecordCloseViewAsync("close_view");
-            TestUtility.ValidateRQEQSize(cly, 2, 1);
-
-            CountlyEventModel model = cly.Events._eventRepo.Dequeue();
-            TestUtility.ViewEventValidator(model, 1, null, null, TestUtility.BaseViewTestSegmentation("open_", true, true), null, null, null, null, TestUtility.TestTimeMetrics());
-            TestUtility.ValidateRQEQSize(cly, 2, 0);
-        }
-
         // 'RecordCloseViewAsync' method in ViewCountlyService.
         // We try to close a view that's not existing
         // If view does not exist nothing should be recorded, nothing should crash
@@ -124,8 +101,7 @@ namespace Assets.Tests.PlayModeTests
             TestUtility.ValidateRQEQSize(cly, 2, 1);
 
             CountlyEventModel model = cly.Events._eventRepo.Dequeue();
-            TestUtility.ViewEventValidator(model, 1, null, null, TestUtility.BaseViewTestSegmentation("open_view", true, true), null, null, null, null, TestUtility.TestTimeMetrics());
-        }
+            TestUtility.ViewEventValidator(model, 1, 0, null, TestUtility.BaseViewTestSegmentation("open_view", true, true), "idv1", "", null, null, TestUtility.TestTimeMetrics());        }
 
         // 'RecordOpenViewAsync' method in ViewCountlyService.
         // Open a view and verify that the event is correctly recorded in the Views repository
@@ -166,7 +142,7 @@ namespace Assets.Tests.PlayModeTests
             await Countly.Instance.Views.RecordOpenViewAsync("open_view", segmentations);
             TestUtility.ValidateRQEQSize(cly, 2, 1);
             CountlyEventModel model = cly.Events._eventRepo.Dequeue();
-            TestUtility.ViewEventValidator(model, 1, null, null, segmentations, null, null, null, null, TestUtility.TestTimeMetrics());
+            TestUtility.ViewEventValidator(model, 1, 0, null, segmentations, "idv1", "", null, null, TestUtility.TestTimeMetrics());
 
             Assert.AreEqual("value1", model.Segmentation["key1"]);
             Assert.IsFalse(model.Segmentation.ContainsKey("key2"));
@@ -175,7 +151,7 @@ namespace Assets.Tests.PlayModeTests
             await Countly.Instance.Views.RecordOpenViewAsync("open_view_2");
             TestUtility.ValidateRQEQSize(cly, 2, 1);
             model = cly.Events._eventRepo.Dequeue();
-            TestUtility.ViewEventValidator(model, 1, null, null, TestUtility.BaseViewTestSegmentation("open_view_2", false, false), null, null, null, null, TestUtility.TestTimeMetrics());
+            TestUtility.ViewEventValidator(model, 1, 0, null, TestUtility.BaseViewTestSegmentation("open_view_2", false, false), "idv2", "idv1", null, null, TestUtility.TestTimeMetrics());
         }
 
         // 'RecordOpenViewAsync' method in ViewCountlyService.
@@ -249,7 +225,7 @@ namespace Assets.Tests.PlayModeTests
             await Countly.Instance.Views.RecordOpenViewAsync("first_view");
             TestUtility.ValidateRQEQSize(cly, 2, 1);
             CountlyEventModel model = cly.Events._eventRepo.Dequeue();
-            TestUtility.ViewEventValidator(model, 1, null, null, TestUtility.BaseViewTestSegmentation("first_view", true, true), null, null, null, null, TestUtility.TestTimeMetrics());
+            TestUtility.ViewEventValidator(model, 1, 0, null, TestUtility.BaseViewTestSegmentation("first_view", true, true), "idv1", "", null, null, TestUtility.TestTimeMetrics());
 
             await Countly.Instance.Device.ChangeDeviceIdWithoutMerge("new device id");
             TestUtility.ValidateRQEQSize(cly, 2, 0);
@@ -275,8 +251,7 @@ namespace Assets.Tests.PlayModeTests
             string viewId = views.StartView(viewNames[0]);
             TestUtility.ValidateRQEQSize(cly, 2, 1);
             CountlyEventModel result = cly.Events._eventRepo.Dequeue();
-            TestUtility.ViewEventValidator(result, 1, 0, null, TestUtility.BaseViewTestSegmentation(viewNames[0], true, true), viewId, "", null, null, TestUtility.TestTimeMetrics());
-            TestUtility.ValidateRQEQSize(cly, 2, 0);
+            TestUtility.ViewEventValidator(result, 1, 0, null, TestUtility.BaseViewTestSegmentation(viewNames[0], true, true), viewId, "", null, null, TestUtility.TestTimeMetrics());            TestUtility.ValidateRQEQSize(cly, 2, 0);
         }
 
         // 'StartView' method in ViewCountlyService class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   * "RecordOpenViewAsync": Use "StartView" instead.
   * "RecordCloseViewAsync": Use "StopView" instead.
   * "ReportActionAsync": This will be removed in the future.
+* Fixed a bug that allowed to make it possible to close non-started views.
 
 ## 23.12.1
 * Added 'UnityWebRequest' as the networking handler for WebGL builds.


### PR DESCRIPTION
Bug: It was possible to call RecordCloseViewAsync with a ''valid'' view name, even if it doesn't exist. It would record a close-view event for the view that's never started.

The offered solution is, without changing core functionality and causing anything to break, we have added the viewdata structure in RecordOpenViewAsync and checked the view id in RecordCloseViewAsync to make sure we return if there's no view with that id