### PR TITLE
Refactoring in Countly.cs

### DIFF
--- a/Assets/Countly/Plugins/CountlySDK/Countly.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Countly.cs
@@ -19,52 +19,29 @@ namespace Plugins.CountlySDK
 {
     public class Countly : MonoBehaviour
     {
-        //SDK limit defaults
-        internal const int MaxKeyLengthDefault = 128;
-        internal const int MaxValueSizeDefault = 256;
-        internal const int MaxSegmentationValuesDefault = 100;
-        internal const int MaxBreadcrumbCountDefault = 100;
-        internal const int MaxStackTraceLinesPerThreadDefault = 30;
-        internal const int MaxStackTraceLineLengthDefault = 200;
-        internal const int MaxStackTraceThreadCountDefault = 30;
-
-        public CountlyAuthModel Auth;
-        public CountlyConfigModel Config;
-        internal RequestCountlyHelper RequestHelper;
-        internal CountlyConfiguration Configuration;
-
         /// <summary>
-        /// Check if SDK has been initialized.
-        /// </summary>
-        /// <returns>bool</returns>
-        public bool IsSDKInitialized { get; private set; }
-
-        private CountlyLogHelper _logHelper;
-        private static Countly _instance = null;
-        internal StorageAndMigrationHelper StorageHelper;
-        internal readonly object lockObj = new object();
-        private List<AbstractBaseService> _listeners = new List<AbstractBaseService>();
-
-        /// <summary>
-        /// Return countly shared instance.
+        /// Return Countly shared instance.
         /// </summary>
         /// <returns>Countly</returns>
         public static Countly Instance
         {
             get {
                 if (_instance == null) {
-
                     GameObject gameObject = new GameObject("_countly");
                     _instance = gameObject.AddComponent<Countly>();
                 }
-
                 return _instance;
-
             }
             internal set {
                 _instance = value;
             }
         }
+
+        /// <summary>
+        /// Check if SDK has been initialized.
+        /// </summary>
+        /// <returns>bool</returns>
+        public bool IsSDKInitialized { get; private set; }
 
         /// <summary>
         /// Check/Update consent for a particular feature.
@@ -89,8 +66,6 @@ namespace Plugins.CountlySDK
         /// </summary>
         /// <returns>EventCountlyService</returns>
         public EventCountlyService Events { get; private set; }
-
-        internal InitializationCountlyService Initialization { get; private set; }
 
         /// <summary>
         /// Exposes functionality to set location parameters.
@@ -120,19 +95,36 @@ namespace Plugins.CountlySDK
         /// Exposes functionality for managing view lifecycle with segmentation options. Includes global view segmentation and adding segmentation to ongoing views.
         /// </summary>
         public IViewModule Views { get; private set; }
-        public MetricHelper MetricHelper { get; private set; }
-        internal SessionCountlyService Session { get; set; }
 
         /// <summary>
         /// Add callbacks to listen to push notification events for when a notification is received and when it is clicked.
         /// </summary>
         /// <returns>NotificationsCallbackService</returns>
         public NotificationsCallbackService Notifications { get; set; }
-
+        public CountlyAuthModel Auth;
+        public CountlyConfigModel Config;
+        internal SessionCountlyService Session { get; set; }
+        internal InitializationCountlyService Initialization { get; private set; }
+        internal RequestCountlyHelper RequestHelper;
+        internal CountlyConfiguration Configuration;
+        internal StorageAndMigrationHelper StorageHelper;
+        internal readonly object lockObj = new object();
         private bool _logSubscribed;
+        private List<AbstractBaseService> _listeners = new List<AbstractBaseService>();
+        private CountlyLogHelper _logHelper;
+        private static Countly _instance = null;
         private PushCountlyService _push;
-
         private CountlyMainThreadHandler countlyMainThreadHandler;
+
+        #region SDK limit defaults
+        internal const int MaxKeyLengthDefault = 128;
+        internal const int MaxValueSizeDefault = 256;
+        internal const int MaxSegmentationValuesDefault = 100;
+        internal const int MaxBreadcrumbCountDefault = 100;
+        internal const int MaxStackTraceLinesPerThreadDefault = 30;
+        internal const int MaxStackTraceLineLengthDefault = 200;
+        internal const int MaxStackTraceThreadCountDefault = 30;
+        #endregion
 
         /// <summary>
         /// Initialize SDK at the start of your app
@@ -160,128 +152,125 @@ namespace Plugins.CountlySDK
                 countlyMainThreadHandler.RunOnMainThread(() => { InitInternal(configuration); });
 
                 // Avoid potential issues with SDK initialization on non-main threads
-                Debug.LogWarning("[Countly] [Init] Initialization process is being moved to the main thread. Ensure this is intended behavior.");
+                Debug.LogWarning("[Countly][Init] Initialization process is being moved to the main thread. Ensure this is intended behavior.");
             }
         }
 
         public void InitInternal(CountlyConfiguration configuration)
         {
             if (IsSDKInitialized) {
-                _logHelper.Error("SDK has already been initialized, 'Init' should not be called a second time!");
+                _logHelper.Error("[Countly][InitInternal] SDK has already been initialized, 'Init' should not be called a second time!");
                 return;
             }
 
             Configuration = configuration;
             _logHelper = new CountlyLogHelper(Configuration);
-
-            _logHelper.Info("[Init] Initializing Countly [SdkName: " + Constants.SdkName + " SdkVersion: " + Constants.SdkVersion + "]");
-
+            _logHelper.Info("[Countly][InitInternal] Initializing Countly [SdkName: " + Constants.SdkName + " SdkVersion: " + Constants.SdkVersion + "]");
             configuration.metricHelper = new MetricHelper(configuration.overridenMetrics);
 
             if (configuration.Parent != null) {
                 transform.parent = configuration.Parent.transform;
             }
 
-            if (string.IsNullOrEmpty(configuration.ServerUrl)) {
-                throw new ArgumentNullException(configuration.ServerUrl, "Server URL is required.");
+            if (string.IsNullOrEmpty(configuration.GetServerUrl())) {
+                throw new ArgumentNullException(configuration.GetServerUrl(), "Server URL is required.");
             }
 
-            if (string.IsNullOrEmpty(configuration.AppKey)) {
-                throw new ArgumentNullException(configuration.AppKey, "App Key is required.");
+            if (string.IsNullOrEmpty(configuration.GetAppKey())) {
+                throw new ArgumentNullException(configuration.GetAppKey(), "App Key is required.");
             }
 
-            if (configuration.ServerUrl[configuration.ServerUrl.Length - 1] == '/') {
-                configuration.ServerUrl = configuration.ServerUrl.Remove(configuration.ServerUrl.Length - 1);
+            if (configuration.GetServerUrl()[configuration.GetServerUrl().Length - 1] == '/') {
+                configuration.ServerUrl = configuration.GetServerUrl().Remove(configuration.GetServerUrl().Length - 1);
             }
 
-            _logHelper.Debug("[Init] SDK initialized with the URL:[" + configuration.ServerUrl + "] and the appKey:[" + configuration.AppKey + "]");
+            _logHelper.Debug("[Countly][InitInternal] SDK initialized with the URL:[" + configuration.GetServerUrl() + "] and the appKey:[" + configuration.GetAppKey() + "]");
 
-
-            if (configuration.SessionDuration < 1) {
-                _logHelper.Error("[Init] provided session duration is less than 1. Replacing it with 1.");
-                configuration.SessionDuration = 1;
+            if (configuration.GetUpdateSessionTimerDelay() < 1) {
+                _logHelper.Error("[Countly][InitInternal] provided session duration is less than 1. Replacing it with 1.");
+                configuration.SetUpdateSessionTimerDelay(1);
             }
-            _logHelper.Debug("[Init] session duration set to [" + configuration.SessionDuration + "]");
+            _logHelper.Debug("[Countly][InitInternal] session duration set to [" + configuration.GetUpdateSessionTimerDelay() + "]");
 
-            if (configuration.EnablePost) {
-                _logHelper.Debug("[Init] Setting HTTP POST to be forced");
-            }
-
-            if (configuration.Salt != null) {
-                _logHelper.Debug("[Init] Enabling tamper protection");
+            if (configuration.IsForcedHttpPostEnabled()) {
+                _logHelper.Debug("[Countly][InitInternal] Setting HTTP POST to be forced");
             }
 
-            if (configuration.NotificationMode != TestMode.None) {
-                _logHelper.Debug("[Init] Enabling push notification");
+            if (configuration.GetParameterTamperingProtectionSalt() != null) {
+                _logHelper.Debug("[Countly][InitInternal] Enabling tamper protection");
+            }
+
+            if (configuration.GetNotificationMode() != TestMode.None) {
+                _logHelper.Debug("[Countly][InitInternal] Enabling push notification");
             }
 
             if (configuration.EnableTestMode) {
-                _logHelper.Warning("[Init] Enabling test mode");
+                _logHelper.Warning("[Countly][InitInternal] Enabling test mode");
             }
 
-            if (configuration.EnableAutomaticCrashReporting) {
-                _logHelper.Debug("[Init] Enabling automatic crash reporting");
+            if (configuration.IsAutomaticCrashReportingEnabled()) {
+                _logHelper.Debug("[Countly][InitInternal] Enabling automatic crash reporting");
             }
 
             // Have a look at the SDK limit values
-            if (configuration.EventQueueThreshold < 1) {
-                _logHelper.Error("[Init] provided event queue size is less than 1. Replacing it with 1.");
-                configuration.EventQueueThreshold = 1;
+            if (configuration.GetEventQueueSizeToSend() < 1) {
+                _logHelper.Error("[Countly][InitInternal] provided event queue size is less than 1. Replacing it with 1.");
+                configuration.SetEventQueueSizeToSend(1);
             }
-            _logHelper.Debug("[Init] event queue size set to [" + configuration.EventQueueThreshold + "]");
+            _logHelper.Debug("[Countly][InitInternal] event queue size set to [" + configuration.GetEventQueueSizeToSend() + "]");
 
-            if (configuration.StoredRequestLimit < 1) {
-                _logHelper.Error("[Init] provided request queue size is less than 1. Replacing it with 1.");
-                configuration.StoredRequestLimit = 1;
+            if (configuration.GetMaxRequestQueueSize() < 1) {
+                _logHelper.Error("[Countly][InitInternal] provided request queue size is less than 1. Replacing it with 1.");
+                configuration.SetMaxRequestQueueSize(1);
             }
-            _logHelper.Debug("[Init] request queue size set to [" + configuration.StoredRequestLimit + "]");
+            _logHelper.Debug("[Countly][InitInternal] request queue size set to [" + configuration.GetMaxRequestQueueSize() + "]");
 
-            if (configuration.MaxKeyLength != MaxKeyLengthDefault) {
-                if (configuration.MaxKeyLength < 1) {
-                    configuration.MaxKeyLength = 1;
-                    _logHelper.Warning("[Init] provided 'maxKeyLength' is less than '1'. Setting it to '1'.");
+            if (configuration.GetMaxKeyLength() != MaxKeyLengthDefault) {
+                if (configuration.GetMaxKeyLength() < 1) {
+                    configuration.SetMaxKeyLength(1);
+                    _logHelper.Warning("[Countly][InitInternal] provided 'maxKeyLength' is less than '1'. Setting it to '1'.");
                 }
-                _logHelper.Info("[Init] provided 'maxKeyLength' override:[" + configuration.MaxKeyLength + "]");
+                _logHelper.Info("[Countly][InitInternal] provided 'maxKeyLength' override:[" + configuration.GetMaxKeyLength() + "]");
             }
 
-            if (configuration.MaxValueSize != MaxValueSizeDefault) {
-                if (configuration.MaxValueSize < 1) {
-                    configuration.MaxValueSize = 1;
-                    _logHelper.Warning("[Init] provided 'maxValueSize' is less than '1'. Setting it to '1'.");
+            if (configuration.GetMaxValueSize() != MaxValueSizeDefault) {
+                if (configuration.GetMaxValueSize() < 1) {
+                    configuration.SetMaxValueSize(1);
+                    _logHelper.Warning("[Countly][InitInternal] provided 'maxValueSize' is less than '1'. Setting it to '1'.");
                 }
-                _logHelper.Info("[Init] provided 'maxValueSize' override:[" + configuration.MaxValueSize + "]");
+                _logHelper.Info("[Countly][InitInternal] provided 'maxValueSize' override:[" + configuration.GetMaxValueSize() + "]");
             }
 
-            if (configuration.MaxSegmentationValues != MaxSegmentationValuesDefault) {
-                if (configuration.MaxSegmentationValues < 1) {
-                    configuration.MaxSegmentationValues = 1;
-                    _logHelper.Warning("[Init] provided 'maxSegmentationValues' is less than '1'. Setting it to '1'.");
+            if (configuration.GetMaxSegmentationValues() != MaxSegmentationValuesDefault) {
+                if (configuration.GetMaxSegmentationValues() < 1) {
+                    configuration.SetMaxSegmentationValues(1);
+                    _logHelper.Warning("[Countly][InitInternal] provided 'maxSegmentationValues' is less than '1'. Setting it to '1'.");
                 }
-                _logHelper.Info("[Init] provided 'maxSegmentationValues' override:[" + configuration.MaxSegmentationValues + "]");
+                _logHelper.Info("[Countly][InitInternal] provided 'maxSegmentationValues' override:[" + configuration.GetMaxSegmentationValues() + "]");
             }
 
-            if (configuration.TotalBreadcrumbsAllowed != MaxBreadcrumbCountDefault) {
-                if (configuration.TotalBreadcrumbsAllowed < 1) {
-                    configuration.TotalBreadcrumbsAllowed = 1;
-                    _logHelper.Warning("[Init] provided 'maxBreadcrumbCount' is less than '1'. Setting it to '1'.");
+            if (configuration.GetMaxBreadcrumbCount() != MaxBreadcrumbCountDefault) {
+                if (configuration.GetMaxBreadcrumbCount() < 1) {
+                    configuration.SetMaxBreadcrumbCount(1);
+                    _logHelper.Warning("[Countly][InitInternal] provided 'maxBreadcrumbCount' is less than '1'. Setting it to '1'.");
                 }
-                _logHelper.Info("[Init] provided 'maxBreadcrumbCount' override:[" + configuration.TotalBreadcrumbsAllowed + "]");
+                _logHelper.Info("[Countly][InitInternal] provided 'maxBreadcrumbCount' override:[" + configuration.GetMaxBreadcrumbCount() + "]");
             }
 
-            if (configuration.MaxStackTraceLinesPerThread != MaxStackTraceLinesPerThreadDefault) {
-                if (configuration.MaxStackTraceLinesPerThread < 1) {
-                    configuration.MaxStackTraceLinesPerThread = 1;
-                    _logHelper.Warning("[Init] provided 'maxStackTraceLinesPerThread' is less than '1'. Setting it to '1'.");
+            if (configuration.GetMaxStackTraceLinesPerThread() != MaxStackTraceLinesPerThreadDefault) {
+                if (configuration.GetMaxStackTraceLinesPerThread() < 1) {
+                    configuration.SetMaxStackTraceLinesPerThread(1);
+                    _logHelper.Warning("[Countly][InitInternal] provided 'maxStackTraceLinesPerThread' is less than '1'. Setting it to '1'.");
                 }
-                _logHelper.Info("[Init] provided 'maxStackTraceLinesPerThread' override:[" + configuration.MaxStackTraceLinesPerThread + "]");
+                _logHelper.Info("[Countly][InitInternal] provided 'maxStackTraceLinesPerThread' override:[" + configuration.GetMaxStackTraceLinesPerThread() + "]");
             }
 
-            if (configuration.MaxStackTraceLineLength != MaxStackTraceLineLengthDefault) {
-                if (configuration.MaxStackTraceLineLength < 1) {
-                    configuration.MaxStackTraceLineLength = 1;
-                    _logHelper.Warning("[Init] provided 'maxStackTraceLineLength' is less than '1'. Setting it to '1'.");
+            if (configuration.GetMaxStackTraceLineLength() != MaxStackTraceLineLengthDefault) {
+                if (configuration.GetMaxStackTraceLineLength() < 1) {
+                    configuration.SetMaxStackTraceLineLength(1);
+                    _logHelper.Warning("[Countly][InitInternal] provided 'maxStackTraceLineLength' is less than '1'. Setting it to '1'.");
                 }
-                _logHelper.Info("[Init] provided 'maxStackTraceLineLength' override:[" + configuration.MaxStackTraceLineLength + "]");
+                _logHelper.Info("[Countly][InitInternal] provided 'maxStackTraceLineLength' override:[" + configuration.GetMaxStackTraceLineLength() + "]");
             }
 
             if (configuration.SafeEventIDGenerator == null) {
@@ -293,24 +282,20 @@ namespace Plugins.CountlySDK
             }
 
             FirstLaunchAppHelper.Process();
-
             RequestBuilder requestBuilder = new RequestBuilder();
             StorageHelper = new StorageAndMigrationHelper(_logHelper, requestBuilder);
             StorageHelper.OpenDB();
 
             IDictionary<string, object> migrationParams = new Dictionary<string, object>()
             {
-                {StorageAndMigrationHelper.key_from_2_to_3_custom_id_set, configuration.DeviceId != null },
+                {StorageAndMigrationHelper.key_from_2_to_3_custom_id_set, configuration.GetDeviceId() != null },
             };
 
             StorageHelper.RunMigration(migrationParams);
-
             Init(requestBuilder, StorageHelper.RequestRepo, StorageHelper.EventRepo, StorageHelper.ConfigDao);
-
-            Device.InitDeviceId(configuration.DeviceId);
+            Device.InitDeviceId(configuration.GetDeviceId());
             OnInitialisationComplete();
-
-            _logHelper.Debug("[Countly] Finished Initializing SDK.");
+            _logHelper.Debug("[Countly][InitInternal] Finished Initializing SDK.");
         }
 
         private void Init(RequestBuilder requestBuilder, RequestRepository requestRepo,
@@ -318,20 +303,16 @@ namespace Plugins.CountlySDK
         {
             CountlyUtils countlyUtils = new CountlyUtils(this);
             RequestHelper = new RequestCountlyHelper(Configuration, _logHelper, countlyUtils, requestBuilder, requestRepo, this);
-
             Consents = new ConsentCountlyService(Configuration, _logHelper, Consents, RequestHelper);
             Events = new EventCountlyService(Configuration, _logHelper, RequestHelper, nonViewEventRepo, Consents, countlyUtils);
-
             Location = new Services.LocationService(Configuration, _logHelper, RequestHelper, Consents);
             Notifications = new NotificationsCallbackService(Configuration, _logHelper);
             ProxyNotificationsService notificationsService = new ProxyNotificationsService(transform, Configuration, _logHelper, InternalStartCoroutine, Events);
             _push = new PushCountlyService(Configuration, _logHelper, RequestHelper, notificationsService, Notifications, Consents);
             Session = new SessionCountlyService(Configuration, _logHelper, Events, RequestHelper, Location, Consents);
-
             CrashReports = new CrashReportsCountlyService(Configuration, _logHelper, RequestHelper, Consents);
             Initialization = new InitializationCountlyService(Configuration, _logHelper, Location, Session, Consents);
             RemoteConfigs = new RemoteConfigCountlyService(Configuration, _logHelper, RequestHelper, countlyUtils, configDao, Consents, requestBuilder);
-
             StarRating = new StarRatingCountlyService(Configuration, _logHelper, Consents, Events);
             UserDetails = new UserDetailsCountlyService(Configuration, _logHelper, RequestHelper, countlyUtils, Consents);
             Views = new ViewCountlyService(this, countlyUtils, Configuration, _logHelper, Events, Consents);
@@ -350,7 +331,6 @@ namespace Plugins.CountlySDK
                     listener.OnInitializationCompleted();
                 }
             }
-
         }
 
         private void CreateListOfIBaseService()
@@ -358,7 +338,7 @@ namespace Plugins.CountlySDK
             _listeners.Clear();
 
             _listeners.Add(_push);
-            _listeners.Add((ViewCountlyService) Views);
+            _listeners.Add((ViewCountlyService)Views);
             _listeners.Add(Events);
             _listeners.Add(Device);
             _listeners.Add(Session);
@@ -407,10 +387,8 @@ namespace Plugins.CountlySDK
             }
 
             _logHelper.Debug("[Countly] ClearStorage");
-
             PlayerPrefs.DeleteAll();
             StorageHelper?.ClearDBData();
-
             StorageHelper?.CloseDB();
         }
 
@@ -478,7 +456,6 @@ namespace Plugins.CountlySDK
             if (type == LogType.Exception) {
                 CrashReports?.SendCrashReportAsync(condition, stackTrace);
             }
-
         }
 
         private void SubscribeAppLog()


### PR DESCRIPTION
To reduce the number of warnings and increase the code readability, I did some refactoring
Refactoring contains:
- Regrouping fields in order
- Switching from deprecated configuration fields to setter/getter methods (which reduces the number of warnings printed)
- Logs in InitInternal method updated
- SDK limit default fields put in a region

2 things need to be noted:
1- We can move this section:
```
if (configuration.GetServerUrl()[configuration.GetServerUrl().Length - 1] == '/') {
                configuration.ServerUrl = configuration.GetServerUrl().Remove(configuration.GetServerUrl().Length - 1);
            }
```
Into configuration. I believe there is no need to do it here. Since we also don't have a setter method for the server URL, this currently can't be refactored in this structure.

2- We moved away from initializing with prefab a long time ago. I planned to do that clean-up here, too, but it requires touching old configuration tests. We can move forward depending on you guys' decision.