### PR TITLE
WebGL Session Bug Fix

### DIFF
--- a/Assets/Countly/Plugins/CountlySDK/Countly.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Countly.cs
@@ -310,7 +310,7 @@ namespace Plugins.CountlySDK
             Notifications = new NotificationsCallbackService(Configuration, _logHelper);
             ProxyNotificationsService notificationsService = new ProxyNotificationsService(transform, Configuration, _logHelper, InternalStartCoroutine, Events);
             _push = new PushCountlyService(Configuration, _logHelper, RequestHelper, notificationsService, Notifications, Consents);
-            Session = new SessionCountlyService(Configuration, _logHelper, Events, RequestHelper, Location, Consents);
+            Session = new SessionCountlyService(Configuration, _logHelper, Events, RequestHelper, Location, Consents, this);
             CrashReports = new CrashReportsCountlyService(Configuration, _logHelper, RequestHelper, Consents);
             Initialization = new InitializationCountlyService(Configuration, _logHelper, Location, Session, Consents);
             RemoteConfigs = new RemoteConfigCountlyService(Configuration, _logHelper, RequestHelper, countlyUtils, configDao, Consents, requestBuilder);

--- a/Assets/Countly/Plugins/CountlySDK/Helpers/RequestCountlyHelper.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Helpers/RequestCountlyHelper.cs
@@ -19,13 +19,11 @@ namespace Plugins.CountlySDK.Helpers
     public class RequestCountlyHelper
     {
         private bool _isQueueBeingProcess;
-
         private readonly CountlyLogHelper Log;
         private readonly CountlyUtils _countlyUtils;
         private readonly CountlyConfiguration _config;
         private readonly RequestBuilder _requestBuilder;
         internal readonly RequestRepository _requestRepo;
-
         private readonly MonoBehaviour _monoBehaviour;
         private readonly int countlyRequestRemoveLimit = 100;
 
@@ -75,22 +73,37 @@ namespace Plugins.CountlySDK.Helpers
         internal async Task ProcessQueue()
         {
             if (_isQueueBeingProcess) {
+                Log.Verbose("[RequestCountlyHelper] ProcessQueue, queue is being processed.");
                 return;
             }
 
             _isQueueBeingProcess = true;
-            CountlyRequestModel[] requests = _requestRepo.Models.ToArray();
+            CountlyRequestModel[] requests = null;
 
-            Log.Verbose("[RequestCountlyHelper] Process queue, requests: " + requests.Length);
+            try {
+                requests = _requestRepo.Models.ToArray();
+                Log.Verbose("[RequestCountlyHelper] ProcessQueue, requests: " + requests.Length);
+            } catch (Exception ex) {
+                Log.Warning($"[RequestCountlyHelper] ProcessQueue, exception occurred while converting Models to array. Exception: {ex}");
+                _isQueueBeingProcess = false;
+                return;
+            }
+
+            // make sure that flag is corrected and exit
+            if (requests.Length == 0) {
+                _isQueueBeingProcess = false;
+                return;
+            }
 
             foreach (CountlyRequestModel reqModel in requests) {
-                //add the remaining request count in RequestData
+                // Add the remaining request count in RequestData
                 reqModel.RequestData += "&rr=" + (requests.Length - 1);
 
                 CountlyResponse response = await ProcessRequest(reqModel);
 
                 if (!response.IsSuccess) {
-                    Log.Verbose("[RequestCountlyHelper] ProcessQueue: Request fail, " + response.ToString());
+                    Log.Verbose("[RequestCountlyHelper] ProcessQueue: Request failed, " + response.ToString());
+                    _isQueueBeingProcess = false;
                     break;
                 }
 
@@ -98,6 +111,7 @@ namespace Plugins.CountlySDK.Helpers
             }
 
             _isQueueBeingProcess = false;
+            Log.Verbose("[RequestCountlyHelper] ProcessQueue, _isQueueBeingProcess is false");
         }
 
         /// <summary>
@@ -109,18 +123,21 @@ namespace Plugins.CountlySDK.Helpers
             bool shouldPost = _config.IsForcedHttpPostEnabled() || model.RequestData.Length > 2000;
 
 #if UNITY_WEBGL
-            // There is not HTTP GET for webGL. We always do a HTTP POST
+            // There is not HTTP GET for WebGL. We always do a HTTP POST
+            Log.Debug($"[RequestCountlyHelper] ProcessRequest, Calling StartProcessRequestRoutine for WebGL");
             return await StartProcessRequestRoutine(_countlyUtils.ServerInputUrl, model.RequestData);
 #else
             if (shouldPost) {
+                Log.Debug($"[RequestCountlyHelper] ProcessRequest, Using HTTP POST");
                 return await Task.Run(() => PostAsync(_countlyUtils.ServerInputUrl, model.RequestData));
             }
+            Log.Debug($"[RequestCountlyHelper] ProcessRequest, Using HTTP GET");
             return await Task.Run(() => GetAsync(_countlyUtils.ServerInputUrl, model.RequestData));
 #endif
         }
 
         /// <summary>
-        ///  An internal function to add a request to request queue.
+        /// An internal function to add a request to request queue.
         /// </summary>
         internal void AddToRequestQueue(Dictionary<string, object> queryParams)
         {
@@ -138,7 +155,7 @@ namespace Plugins.CountlySDK.Helpers
                     string hex = _countlyUtils.GetStringFromBytes(bytes);
 
                     query += "&checksum256=" + hex;
-                    Log.Debug("BuildGetRequest: query = " + query);
+                    Log.Debug($"[RequestCountlyHelper] AddChecksum, Checksum added query = [{query}]");
                 }
             }
 
@@ -153,7 +170,7 @@ namespace Plugins.CountlySDK.Helpers
         /// <returns></returns>
         internal async Task<CountlyResponse> GetAsync(string uri, string data)
         {
-            Log.Verbose("[RequestCountlyHelper] GetAsync request: " + uri + " params: " + data);
+            Log.Verbose("[RequestCountlyHelper] GetAsync, calling with request: " + uri + " params: " + data);
 
             CountlyResponse countlyResponse = new CountlyResponse();
             string query = AddChecksum(data);
@@ -171,7 +188,6 @@ namespace Plugins.CountlySDK.Helpers
                         countlyResponse.StatusCode = code;
                         countlyResponse.IsSuccess = IsSuccess(countlyResponse);
                     }
-
                 }
             } catch (WebException ex) {
                 countlyResponse.ErrorMessage = ex.Message;
@@ -188,8 +204,7 @@ namespace Plugins.CountlySDK.Helpers
                 }
             }
 
-            Log.Verbose("[RequestCountlyHelper] GetAsync request: " + url + " params: " + query + " response: " + countlyResponse.ToString());
-
+            Log.Verbose($"[RequestCountlyHelper] GetAsync, Request URL: [{url}], Params: [{query}], Response: [{countlyResponse.ToString()}]");
             return countlyResponse;
         }
 
@@ -242,8 +257,7 @@ namespace Plugins.CountlySDK.Helpers
                 }
             }
 
-            Log.Verbose("[RequestCountlyHelper] PostAsync request: " + uri + " body: " + data + " response: " + countlyResponse.ToString());
-
+            Log.Verbose($"[RequestCountlyHelper] PostAsync, Request URL: [{uri}], Body: [{data}], Response: [{countlyResponse.ToString()}]");
             return countlyResponse;
         }
 
@@ -255,11 +269,26 @@ namespace Plugins.CountlySDK.Helpers
         /// <returns></returns>
         private Task<CountlyResponse> StartProcessRequestRoutine(string uri, string data)
         {
+            Log.Debug($"[RequestCountlyHelper] StartProcessRequestRoutine, Start");
             TaskCompletionSource<CountlyResponse> tcs = new TaskCompletionSource<CountlyResponse>();
 
-            _monoBehaviour.StartCoroutine(ProcessRequestCoroutine(uri, data, (response) => {
-                tcs.SetResult(response);
-            }));
+            try {
+                // 'IsObjectMonoBehaviour can only be called from the main thread'
+                // That's why we have to move it to main thread.
+                CountlyMainThreadHandler.Instance.RunOnMainThread(() => {
+                    try {
+                        _monoBehaviour.StartCoroutine(ProcessRequestCoroutine(uri, data, (response) => {
+                            tcs.SetResult(response);
+                        }));
+                    } catch (Exception ex) {
+                        Log.Error($"[RequestCountlyHelper] StartProcessRequestRoutine, Exception occurred while starting coroutine. Exception: [{ex}]");
+                        tcs.SetException(ex);
+                    }
+                });
+            } catch (Exception ex) {
+                Log.Error($"[RequestCountlyHelper] StartProcessRequestRoutine, Exception occurred while queueing to main thread. Exception: [{ex}]");
+                tcs.SetException(ex);
+            }
 
             return tcs.Task;
         }
@@ -273,17 +302,15 @@ namespace Plugins.CountlySDK.Helpers
         /// <returns></returns>
         private IEnumerator ProcessRequestCoroutine(string uri, string data, Action<CountlyResponse> callback)
         {
+            Log.Debug($"[RequestCountlyHelper] ProcessRequestCoroutine, Start");
             CountlyResponse countlyResponse = new CountlyResponse();
 
             string query = AddChecksum(data);
             string url = uri + query;
 
             using (UnityWebRequest webRequest = UnityWebRequest.Put(url, data)) {
-
                 webRequest.method = UnityWebRequest.kHttpVerbPOST;
-
                 yield return webRequest.SendWebRequest();
-
                 string[] pages = url.Split('?');
                 int page = pages.Length - 1;
                 int code = (int)webRequest.responseCode;
@@ -292,13 +319,17 @@ namespace Plugins.CountlySDK.Helpers
                 countlyResponse.ErrorMessage = webRequest.error;
                 countlyResponse.StatusCode = code;
                 countlyResponse.IsSuccess = IsSuccess(countlyResponse);
-
-                Log.Debug($"[RequestCountlyHelper] ProcessRequestCoroutine request url: [{uri}] body: [{pages[page]}] response: [{countlyResponse}]");
+                Log.Debug($"[RequestCountlyHelper] ProcessRequestCoroutine, Request URL: [{uri}], Body: [{pages[page]}], Response: [{countlyResponse}]");
             }
-
+            Log.Debug($"[RequestCountlyHelper] ProcessRequestCoroutine, Process completed invoking callback.");
             callback?.Invoke(countlyResponse);
         }
 
+        /// <summary>
+        /// Determines if a CountlyResponse indicates a successful request based on the HTTP status code and the presence of a "result" key in the JSON response data.
+        /// </summary>
+        /// <param name="countlyResponse">The CountlyResponse object to evaluate.</param>
+        /// <returns>True if the status code is between 200 and 299 and the response data contains a "result" key; otherwise, false.</returns>
         private bool IsSuccess(CountlyResponse countlyResponse)
         {
             if (countlyResponse.StatusCode >= 200 && countlyResponse.StatusCode < 300) {
@@ -308,12 +339,11 @@ namespace Plugins.CountlySDK.Helpers
                     if (json.ContainsKey("result")) {
                         return true;
                     }
-                } catch(JsonException) {
-                    Log.Debug("[RequestCountlyHelper] IsSuccess : Returned request is not a JSON object");
+                } catch (JsonException ex) {
+                    Log.Debug($"[RequestCountlyHelper] IsSuccess : Returned request is not a JSON object. Exception: [{ex}]");
                     return false;
-                } 
+                }
             }
-
             return false;
         }
     }

--- a/Assets/Countly/Plugins/CountlySDK/Services/SessionCountlyService.cs
+++ b/Assets/Countly/Plugins/CountlySDK/Services/SessionCountlyService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Timers;
@@ -6,6 +7,7 @@ using Newtonsoft.Json;
 using Plugins.CountlySDK.Enums;
 using Plugins.CountlySDK.Helpers;
 using Plugins.CountlySDK.Models;
+using UnityEngine;
 
 namespace Plugins.CountlySDK.Services
 {
@@ -22,11 +24,11 @@ namespace Plugins.CountlySDK.Services
         private readonly LocationService _locationService;
         private readonly EventCountlyService _eventService;
         internal readonly RequestCountlyHelper _requestCountlyHelper;
-
+        private readonly MonoBehaviour _monoBehaviour;
         bool isInternalTimerStopped;
 
         internal SessionCountlyService(CountlyConfiguration configuration, CountlyLogHelper logHelper, EventCountlyService eventService,
-            RequestCountlyHelper requestCountlyHelper, LocationService locationService, ConsentCountlyService consentService) : base(configuration, logHelper, consentService)
+            RequestCountlyHelper requestCountlyHelper, LocationService locationService, ConsentCountlyService consentService, MonoBehaviour monoBehaviour) : base(configuration, logHelper, consentService)
         {
             Log.Debug("[SessionCountlyService] Initializing.");
             if (configuration.IsAutomaticSessionTrackingDisabled) {
@@ -36,6 +38,7 @@ namespace Plugins.CountlySDK.Services
             _eventService = eventService;
             _locationService = locationService;
             _requestCountlyHelper = requestCountlyHelper;
+            _monoBehaviour = monoBehaviour;
 
             if (_configuration.IsAutomaticSessionTrackingDisabled) {
                 Log.Verbose("[Countly][CountlyConfiguration] Automatic session tracking disabled!");
@@ -72,10 +75,34 @@ namespace Plugins.CountlySDK.Services
         /// </summary>
         private void InitSessionTimer()
         {
+#if UNITY_WEBGL
+            _monoBehaviour.StartCoroutine(SessionTimerCoroutine());
+#else
             _sessionTimer = new Timer { Interval = _configuration.GetUpdateSessionTimerDelay() * 1000 };
             _sessionTimer.Elapsed += SessionTimerOnElapsedAsync;
             _sessionTimer.AutoReset = true;
             _sessionTimer.Start();
+#endif
+        }
+
+        private IEnumerator SessionTimerCoroutine()
+        {
+            Log.Debug("[SessionCountlyService] SessionTimerCoroutine, Start");
+
+            if (isInternalTimerStopped) {
+                yield break;
+            }
+
+            yield return new WaitForSeconds(_configuration.GetUpdateSessionTimerDelay());
+
+            _eventService.AddEventsToRequestQueue();
+            _ = _requestCountlyHelper.ProcessQueue();
+
+            if (!_configuration.IsAutomaticSessionTrackingDisabled) {
+                _ = ExtendSessionAsync();
+            }
+
+            Log.Debug("[SessionCountlyService] SessionTimerCoroutine, Coroutine completed.");
         }
 
         /// <summary>
@@ -86,8 +113,10 @@ namespace Plugins.CountlySDK.Services
         {
             isInternalTimerStopped = true;
 
-            if (_sessionTimer != null)
-            {
+            #if UNITY_WEBGL
+            _monoBehaviour.StopCoroutine(SessionTimerCoroutine());
+            #else
+            if (_sessionTimer != null) {
                 // Unsubscribe from the Elapsed event
                 _sessionTimer.Elapsed -= SessionTimerOnElapsedAsync;
 
@@ -95,6 +124,7 @@ namespace Plugins.CountlySDK.Services
                 _sessionTimer.Stop();
                 _sessionTimer.Dispose();
             }
+            #endif
         }
 
         /// <summary>
@@ -190,7 +220,7 @@ namespace Plugins.CountlySDK.Services
                 Log.Warning("[SessionCountlyService] EndSessionAsync: The session isn't started yet!");
                 return;
             }
-            
+
             IsSessionInitiated = false;
             _eventService.AddEventsToRequestQueue();
             Dictionary<string, object> requestParams = new Dictionary<string, object>
@@ -199,11 +229,9 @@ namespace Plugins.CountlySDK.Services
                     {"session_duration",  Convert.ToInt32((DateTime.Now - _lastSessionRequestTime).TotalSeconds)}
                 };
 
-
             _requestCountlyHelper.AddToRequestQueue(requestParams);
             await _requestCountlyHelper.ProcessQueue();
         }
-
 
         /// <summary>
         /// Extends a session by another session duration provided in configuration. By default session duration is 60 seconds.
@@ -232,6 +260,10 @@ namespace Plugins.CountlySDK.Services
 
             _requestCountlyHelper.AddToRequestQueue(requestParams);
             await _requestCountlyHelper.ProcessQueue();
+            
+            #if UNITY_WEBGL
+            _monoBehaviour.StartCoroutine(SessionTimerCoroutine());
+            #endif
         }
 
         #region override Methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   * "ReportActionAsync": This will be removed in the future.
 * Fixed a bug that allowed to make it possible to close non-started views.
 * Fixed issues that allowed to record User Profiles without consent.
+* Fixed a bug that caused requests being stuck in the queue for WebGL build targets.
 
 ## 23.12.1
 * Added 'UnityWebRequest' as the networking handler for WebGL builds.


### PR DESCRIPTION
Apparently just fixing the `RequestCountlyHelper` is not enough. I built the example app in WebGL and realized that session timer was never elapsing. After a research i learned that `System.Timers.Timer` is designed for a multithreaded environment which means not for WebGL. It also sadly wasn't possible to catch this within Unity Editor. 

For now as a solution I have added a coroutine called `SessionTimerCoroutine` in `SessionCountlyService.cs` to make sure it does work. Built the example app again and session updates was happening correctly. Would love you guys' opinion on this part too