### PR TITLE
Test fixes

### DIFF
--- a/Assets/Tests/PlayModeTests/CrashTests.cs
+++ b/Assets/Tests/PlayModeTests/CrashTests.cs
@@ -3,6 +3,8 @@ using NUnit.Framework;
 using UnityEngine;
 using Plugins.CountlySDK.Models;
 using Plugins.CountlySDK;
+using UnityEngine.TestTools;
+using System.Threading.Tasks;
 using System.Web;
 using System.Collections.Specialized;
 using Newtonsoft.Json.Linq;
@@ -58,8 +60,8 @@ namespace Assets.Tests.PlayModeTests
         // 'SendCrashReportAsync' method in CrashReportsCountlyService
         // Checks if crash service is working if no 'Crash' consent is given.
         // If consent is not given, no report should be sent.
-        [Test]
-        public async void CrashConsent()
+        [UnityTest]
+        public IEnumerator CrashConsent()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfigConsent(new Plugins.CountlySDK.Enums.Consents[] { });
             Countly.Instance.Init(configuration);
@@ -74,7 +76,7 @@ namespace Assets.Tests.PlayModeTests
                 { "Retry Attempts", "10" }
             };
 
-            await Countly.Instance.CrashReports.SendCrashReportAsync("message", "StackTrace", seg);
+            yield return Countly.Instance.CrashReports.SendCrashReportAsync("message", "StackTrace", seg).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
         }
 
@@ -98,8 +100,8 @@ namespace Assets.Tests.PlayModeTests
         // 'SendCrashReportAsync' method in CrashReportsCountlyService.
         // Validate SDK limits on crash parameters
         // The provided values should be limited by the limits
-        [Test]
-        public async void CrashLimits()
+        [UnityTest]
+        public IEnumerator CrashLimits()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetMaxValueSize(5)
@@ -121,7 +123,7 @@ namespace Assets.Tests.PlayModeTests
                 { "Temp", "100" }
             };
 
-            await Countly.Instance.CrashReports.SendCrashReportAsync("message", "StackTrace_1\nStackTrace_2\nStackTrace_3", seg);
+            yield return Countly.Instance.CrashReports.SendCrashReportAsync("message", "StackTrace_1\nStackTrace_2\nStackTrace_3", seg).AsCoroutine();
 
             // TODO: Instead use ValidateRQEQSize from TestUtility
             Assert.AreEqual(1, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
@@ -142,8 +144,8 @@ namespace Assets.Tests.PlayModeTests
         // 'SendCrashReportAsync' deprecated method in CrashReportsCountlyService.
         // We verify if a CrashReport is sent with empty, null or whitespace messages
         // Deprecated function with LogType variable should still have the functionality and valid message should be sent. 
-        [Test]
-        public async void SendCrashReportAsyncDeprecated()
+        [UnityTest]
+        public IEnumerator SendCrashReportAsyncDeprecated()
         {
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Clear();
@@ -151,20 +153,20 @@ namespace Assets.Tests.PlayModeTests
             Assert.IsNotNull(Countly.Instance.CrashReports);
             Assert.AreEqual(0, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
 
-            await Countly.Instance.CrashReports.SendCrashReportAsync(null, "stackTrace", LogType.Log, null);
+            yield return Countly.Instance.CrashReports.SendCrashReportAsync(null, "stackTrace", LogType.Log, null).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
 
-            await Countly.Instance.CrashReports.SendCrashReportAsync(" ", "stackTrace", LogType.Log, null);
+            yield return Countly.Instance.CrashReports.SendCrashReportAsync(" ", "stackTrace", LogType.Log, null).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
 
-            await Countly.Instance.CrashReports.SendCrashReportAsync("", "stackTrace", LogType.Log, null);
+            yield return Countly.Instance.CrashReports.SendCrashReportAsync("", "stackTrace", LogType.Log, null).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
 
             Dictionary<string, object> seg = new Dictionary<string, object>{
                 { "ExampleSegmentation", "Segment1"},
             };
 
-            await Countly.Instance.CrashReports.SendCrashReportAsync("Crash message", "stackTrace", LogType.Log, seg);
+            yield return Countly.Instance.CrashReports.SendCrashReportAsync("Crash message", "stackTrace", LogType.Log, seg).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
 
             CountlyRequestModel requestModel = Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Dequeue();
@@ -175,8 +177,8 @@ namespace Assets.Tests.PlayModeTests
         // 'SendCrashReportAsync' method in CrashReportsCountlyService.
         // We verify if a CrashReport is sent with empty, null or whitespace messages
         // When provided a valid message, a crash report should be sent.
-        [Test]
-        public async void SendCrashReportAsync()
+        [UnityTest]
+        public IEnumerator SendCrashReportAsync()
         {
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Clear();
@@ -185,13 +187,13 @@ namespace Assets.Tests.PlayModeTests
             Assert.AreEqual(0, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
 
             //crashes with bad params are not recorded
-            await Countly.Instance.CrashReports.SendCrashReportAsync("", "StackTrace", null);
+            yield return Countly.Instance.CrashReports.SendCrashReportAsync("", "StackTrace", null).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
 
-            await Countly.Instance.CrashReports.SendCrashReportAsync(null, "StackTrace", null);
+            yield return Countly.Instance.CrashReports.SendCrashReportAsync(null, "StackTrace", null).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
 
-            await Countly.Instance.CrashReports.SendCrashReportAsync(" ", "StackTrace", null);
+            yield return Countly.Instance.CrashReports.SendCrashReportAsync(" ", "StackTrace", null).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
 
 
@@ -201,7 +203,7 @@ namespace Assets.Tests.PlayModeTests
             };
 
             // Send CrashReport with valid message and segmentation
-            await Countly.Instance.CrashReports.SendCrashReportAsync("message", "StackTrace", seg);
+            yield return Countly.Instance.CrashReports.SendCrashReportAsync("message", "StackTrace", seg).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
 
             CountlyRequestModel requestModel = Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Dequeue();
@@ -273,8 +275,8 @@ namespace Assets.Tests.PlayModeTests
         // We provide segmentation with crash and check every supported data type
         // string, bool, float, double, string, long and, their list and arrays are supported types
         // Supported data types should be recorded, unsupported types should be removed correctly
-        [Test]
-        public async void SegmentationDataTypeValidation()
+        [UnityTest]
+        public IEnumerator SegmentationDataTypeValidation()
         {
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Countly cly = Countly.Instance;
@@ -308,7 +310,7 @@ namespace Assets.Tests.PlayModeTests
 
             Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Clear();
             Assert.IsNotNull(Countly.Instance.CrashReports);
-            await Countly.Instance.CrashReports.SendCrashReportAsync("message", "StackTrace_1\nStackTrace_2\nStackTrace_3", seg);
+            yield return Countly.Instance.CrashReports.SendCrashReportAsync("message", "StackTrace_1\nStackTrace_2\nStackTrace_3", seg).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 1, 0);
             CountlyRequestModel requestModel = Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Dequeue();
             NameValueCollection collection = HttpUtility.ParseQueryString(requestModel.RequestData);

--- a/Assets/Tests/PlayModeTests/DeviceIdTests.cs
+++ b/Assets/Tests/PlayModeTests/DeviceIdTests.cs
@@ -2,6 +2,9 @@ using NUnit.Framework;
 using UnityEngine;
 using Plugins.CountlySDK.Models;
 using Plugins.CountlySDK;
+using UnityEngine.TestTools;
+using System.Collections;
+using System.Threading.Tasks;
 using System.Web;
 using System.Collections.Specialized;
 using Plugins.CountlySDK.Enums;
@@ -73,8 +76,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates the working of methods 'ChangeDeviceIdWithMerge' and 'ChangeDeviceIdWithoutMerge' on giving same device id.
         /// </summary>
-        [Test]
-        public async void TestSameDeviceIdLogic()
+        [UnityTest]
+        public IEnumerator TestSameDeviceIdLogic()
         {
             ConfigureAndInitSDK("device_id");
 
@@ -83,11 +86,11 @@ namespace Assets.Tests.PlayModeTests
             Assert.AreEqual(DeviceIdType.DeveloperProvided, Countly.Instance.Device.DeviceIdType);
 
             Countly.Instance.Device._requestCountlyHelper._requestRepo.Clear();
-            await Countly.Instance.Device.ChangeDeviceIdWithMerge("device_id");
+            yield return Countly.Instance.Device.ChangeDeviceIdWithMerge("device_id").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Device._requestCountlyHelper._requestRepo.Count);
             Assert.AreEqual(DeviceIdType.DeveloperProvided, Countly.Instance.Device.DeviceIdType);
 
-            await Countly.Instance.Device.ChangeDeviceIdWithoutMerge("device_id");
+            yield return Countly.Instance.Device.ChangeDeviceIdWithoutMerge("device_id").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Device._requestCountlyHelper._requestRepo.Count);
             Assert.AreEqual(DeviceIdType.DeveloperProvided, Countly.Instance.Device.DeviceIdType);
 
@@ -97,8 +100,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates the functionality of method 'ChangeDeviceIdWithoutMerge'.
         /// </summary>
-        [Test]
-        public async void TestDeviceServiceMethod_ChangeDeviceIdWithoutMerge()
+        [UnityTest]
+        public IEnumerator TestDeviceServiceMethod_ChangeDeviceIdWithoutMerge()
         {
             ConfigureAndInitSDK();
             Assert.IsNotNull(Countly.Instance.Consents);
@@ -106,7 +109,7 @@ namespace Assets.Tests.PlayModeTests
 
             string oldDeviceId = Countly.Instance.Device.DeviceId;
             Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Clear();
-            await Countly.Instance.Device.ChangeDeviceIdWithoutMerge("new_device_id");
+            yield return Countly.Instance.Device.ChangeDeviceIdWithoutMerge("new_device_id").AsCoroutine();
             //RQ will have begin session and end session requests
             Assert.AreEqual(2, Countly.Instance.Device._requestCountlyHelper._requestRepo.Count);
             Assert.AreEqual(DeviceIdType.DeveloperProvided, Countly.Instance.Device.DeviceIdType);
@@ -127,8 +130,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates the consent removal after changing the device id without merging.
         /// </summary>
-        [Test]
-        public async void TestConsentRemoval_ChangeDeviceIdWithoutMerge()
+        [UnityTest]
+        public IEnumerator TestConsentRemoval_ChangeDeviceIdWithoutMerge()
         {
             ConfigureAndInitSDK(null, true, new Consents[] { Consents.Crashes, Consents.Events, Consents.Clicks, Consents.StarRating, Consents.Views, Consents.Users, Consents.Sessions, Consents.Push, Consents.RemoteConfig, Consents.Location, Consents.Feedback });
             Assert.IsNotNull(Countly.Instance.Consents);
@@ -136,7 +139,7 @@ namespace Assets.Tests.PlayModeTests
 
             Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Clear();
             string oldDeviceId = Countly.Instance.Device.DeviceId;
-            await Countly.Instance.Device.ChangeDeviceIdWithoutMerge("new_device_id_1");
+            yield return Countly.Instance.Device.ChangeDeviceIdWithoutMerge("new_device_id_1").AsCoroutine();
             //RQ will have end session request
             Assert.AreEqual(1, Countly.Instance.Device._requestCountlyHelper._requestRepo.Count);
             Assert.AreEqual(DeviceIdType.DeveloperProvided, Countly.Instance.Device.DeviceIdType);
@@ -158,8 +161,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates functionality of method 'ChangeDeviceIdWithMerge'.
         /// </summary>
-        [Test]
-        public async void TestConset_ChangeDeviceIdWithMerge()
+        [UnityTest]
+        public IEnumerator TestConset_ChangeDeviceIdWithMerge()
         {
             ConfigureAndInitSDK();
 
@@ -168,7 +171,7 @@ namespace Assets.Tests.PlayModeTests
 
             string oldDeviceId = Countly.Instance.Device.DeviceId;
             Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Clear();
-            await Countly.Instance.Device.ChangeDeviceIdWithMerge("new_device_id");
+            yield return Countly.Instance.Device.ChangeDeviceIdWithMerge("new_device_id").AsCoroutine();
             //RQ will have begin session and end session requests
             Assert.AreEqual(1, Countly.Instance.Device._requestCountlyHelper._requestRepo.Count);
             Assert.AreEqual(DeviceIdType.DeveloperProvided, Countly.Instance.Device.DeviceIdType);
@@ -185,8 +188,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates the functionality of method 'ChangeDeviceIdWithoutMerge' when automatic session tracking is enabled.
         /// </summary>
-        [Test]
-        public async void TestMethod_ChangeDeviceIdWithoutMerge_WhenAutomaticSessionTrackingEnabled()
+        [UnityTest]
+        public IEnumerator TestMethod_ChangeDeviceIdWithoutMerge_WhenAutomaticSessionTrackingEnabled()
         {
             ConfigureAndInitSDK(null, true, new Consents[] { Consents.Crashes, Consents.Events, Consents.Clicks, Consents.StarRating, Consents.Views, Consents.Users, Consents.Sessions, Consents.Push, Consents.RemoteConfig, Consents.Location, Consents.Feedback });
             Assert.IsNotNull(Countly.Instance.Consents);
@@ -194,7 +197,7 @@ namespace Assets.Tests.PlayModeTests
 
             string oldDeviceId = Countly.Instance.Device.DeviceId;
             Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Clear();
-            await Countly.Instance.Device.ChangeDeviceIdWithoutMerge("new_device_id");
+            yield return Countly.Instance.Device.ChangeDeviceIdWithoutMerge("new_device_id").AsCoroutine();
             //RQ will have end session request
             Assert.AreEqual(1, Countly.Instance.Device._requestCountlyHelper._requestRepo.Count);
             Assert.AreEqual(DeviceIdType.DeveloperProvided, Countly.Instance.Device.DeviceIdType);
@@ -229,8 +232,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates the functionality of method 'ChangeDeviceIdWithoutMerge' when automatic session tracking is disabled.
         /// </summary>
-        [Test]
-        public async void TestMethod_ChangeDeviceIdWithoutMerge_WhenAutomaticSessionTrackingIsDisabled()
+        [UnityTest]
+        public IEnumerator TestMethod_ChangeDeviceIdWithoutMerge_WhenAutomaticSessionTrackingIsDisabled()
         {
             ConfigureAndInitSDK(null, true, new Consents[] { Consents.Crashes, Consents.Events, Consents.Clicks, Consents.StarRating, Consents.Views, Consents.Users, Consents.Sessions, Consents.Push, Consents.RemoteConfig, Consents.Location, Consents.Feedback }, true);
 
@@ -238,7 +241,7 @@ namespace Assets.Tests.PlayModeTests
             Assert.AreEqual(DeviceIdType.SDKGenerated, Countly.Instance.Device.DeviceIdType);
 
             Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Clear();
-            await Countly.Instance.Device.ChangeDeviceIdWithoutMerge("new_device_id");
+            yield return Countly.Instance.Device.ChangeDeviceIdWithoutMerge("new_device_id").AsCoroutine();
             //Since automatic session tracking is disabled, RQ will be empty
             Assert.AreEqual(0, Countly.Instance.Device._requestCountlyHelper._requestRepo.Count);
             Assert.AreEqual(DeviceIdType.DeveloperProvided, Countly.Instance.Device.DeviceIdType);

--- a/Assets/Tests/PlayModeTests/EventTests.cs
+++ b/Assets/Tests/PlayModeTests/EventTests.cs
@@ -4,6 +4,8 @@ using NUnit.Framework;
 using UnityEngine.TestTools;
 using Plugins.CountlySDK.Models;
 using Plugins.CountlySDK;
+using System.Collections;
+using System.Threading.Tasks;
 using Plugins.CountlySDK.Enums;
 using Newtonsoft.Json.Linq;
 using System;
@@ -70,8 +72,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It checks the working of event service if no event consent is given.
         /// </summary>
-        [Test]
-        public async void TestEventConsent()
+        [UnityTest]
+        public IEnumerator TestEventConsent()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetRequiresConsent(true);
@@ -82,11 +84,11 @@ namespace Assets.Tests.PlayModeTests
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("test_event");
+            yield return Countly.Instance.Events.RecordEventAsync("test_event").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: null, sum: 23, duration: 5);
+            yield return Countly.Instance.Events.RecordEventAsync("test_event", segmentation: null, sum: 23, duration: 5).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
 
@@ -135,8 +137,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates the cancelation of timed events on changing device id without merge.
         /// </summary>
-        [Test]
-        public async void TestTimedEventsCancelationOnDeviceIdChange()
+        [UnityTest]
+        public IEnumerator TestTimedEventsCancelationOnDeviceIdChange()
         {
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
 
@@ -148,7 +150,7 @@ namespace Assets.Tests.PlayModeTests
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(2, Countly.Instance.Events._timedEvents.Count);
 
-            await Countly.Instance.Device.ChangeDeviceIdWithoutMerge("new_device_id");
+            yield return Countly.Instance.Device.ChangeDeviceIdWithoutMerge("new_device_id").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
             Assert.AreEqual(0, Countly.Instance.Events._timedEvents.Count);
         }
@@ -242,21 +244,21 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates functionality of method 'RecordEventAsync'.
         /// </summary>
-        [Test]
-        public async void TestEventMethod_RecordEventAsync()
+        [UnityTest]
+        public IEnumerator TestEventMethod_RecordEventAsync()
         {
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("test_event");
+            yield return Countly.Instance.Events.RecordEventAsync("test_event").AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 0, 1, null, null);
 
 
-            await Countly.Instance.Events.RecordEventAsync("test_event1", segmentation: null, count: 5, duration: null, sum: null);
+            yield return Countly.Instance.Events.RecordEventAsync("test_event1", segmentation: null, count: 5, duration: null, sum: null).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
@@ -266,8 +268,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates the working of event service if 'EventQueueThreshold' limit reach.
         /// </summary>
-        [Test]
-        public async void TestEvent_EventQueueThreshold_Limit()
+        [UnityTest]
+        public IEnumerator TestEvent_EventQueueThreshold_Limit()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetEventQueueSizeToSend(3);
@@ -276,21 +278,21 @@ namespace Assets.Tests.PlayModeTests
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("test_event_1");
+            yield return Countly.Instance.Events.RecordEventAsync("test_event_1").AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("test_event_2");
+            yield return Countly.Instance.Events.RecordEventAsync("test_event_2").AsCoroutine();
             Assert.AreEqual(2, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("test_event_3");
+            yield return Countly.Instance.Events.RecordEventAsync("test_event_3").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
         }
 
         /// <summary>
         /// It validates functionality of method 'ReportCustomEventAsync'.
         /// </summary>
-        [Test]
-        public async void TestEventMethod_ReportCustomEventAsync()
+        [UnityTest]
+        public IEnumerator TestEventMethod_ReportCustomEventAsync()
         {
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
@@ -303,7 +305,7 @@ namespace Assets.Tests.PlayModeTests
 
             SegmentModel segmentModel = new SegmentModel(segments);
 
-            await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segmentModel, sum: 23, duration: 5);
+            yield return Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segmentModel, sum: 23, duration: 5).AsCoroutine();
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "test_event", 23, 1, 5, segments);
@@ -312,8 +314,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates the event limits.
         /// </summary>
-        [Test]
-        public async void TestEventLimits()
+        [UnityTest]
+        public IEnumerator TestEventLimits()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetMaxKeyLength(4)
@@ -331,7 +333,7 @@ namespace Assets.Tests.PlayModeTests
 
             SegmentModel segmentModel = new SegmentModel(segments);
 
-            await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segmentModel, sum: 23, duration: 5);
+            yield return Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segmentModel, sum: 23, duration: 5).AsCoroutine();
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
 
@@ -349,8 +351,8 @@ namespace Assets.Tests.PlayModeTests
         /// string, bool, float, double, string, long and, their list and arrays are supported types
         /// Supported data types should be recorded, unsupported types should be removed correctly
         /// </summary>
-        [Test]
-        public async void SegmentationDataTypeValidation()
+        [UnityTest]
+        public IEnumerator SegmentationDataTypeValidation()
         {
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.Events);
@@ -379,7 +381,7 @@ namespace Assets.Tests.PlayModeTests
                 { "LongList", new List<long> { 10000000000L, 20000000000L, 30000000000L } }
             };
 
-            await Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segments, sum: 23, duration: 5);
+            yield return Countly.Instance.Events.RecordEventAsync("test_event", segmentation: segments, sum: 23, duration: 5).AsCoroutine();
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
 
@@ -408,8 +410,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates the mandatory and optional parameters of events.
         /// </summary>
-        [Test]
-        public async void TestEventsParameters()
+        [UnityTest]
+        public IEnumerator TestEventsParameters()
         {
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
 
@@ -421,22 +423,22 @@ namespace Assets.Tests.PlayModeTests
                 { "key2", "value2"}
             };
 
-            await Countly.Instance.Events.RecordEventAsync("", segmentation: segments, sum: 23, duration: 5);
+            yield return Countly.Instance.Events.RecordEventAsync("", segmentation: segments, sum: 23, duration: 5).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("");
+            yield return Countly.Instance.Events.RecordEventAsync("").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync(null, segmentation: segments, sum: 23, duration: 5);
+            yield return Countly.Instance.Events.RecordEventAsync(null, segmentation: segments, sum: 23, duration: 5).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync(" ");
+            yield return Countly.Instance.Events.RecordEventAsync(" ").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("key", segmentation: null, sum: 23, duration: 5);
+            yield return Countly.Instance.Events.RecordEventAsync("key", segmentation: null, sum: 23, duration: 5).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("key", segmentation: segments, sum: 23, duration: null);
+            yield return Countly.Instance.Events.RecordEventAsync("key", segmentation: segments, sum: 23, duration: null).AsCoroutine();
             Assert.AreEqual(2, Countly.Instance.Events._eventRepo.Count);
         }
 
@@ -444,8 +446,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates specific keys consents.
         /// </summary>
-        [Test]
-        public async void TestSpecificKeysConsent()
+        [UnityTest]
+        public IEnumerator TestSpecificKeysConsent()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetRequiresConsent(true);
@@ -455,36 +457,36 @@ namespace Assets.Tests.PlayModeTests
             Assert.IsNotNull(Countly.Instance.Events);
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("event");
+            yield return Countly.Instance.Events.RecordEventAsync("event").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_view");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_view").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_nps").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_survey");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_survey").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_push_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_orientation");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_orientation").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
         }
 
         /// <summary>
         /// It validates 'recordEvent' against view specific key '[CLY]_view'.
         /// </summary>
-        [Test]
-        public async void TestEventMethod_RecordEventAgainstViewKey()
+        [UnityTest]
+        public IEnumerator TestEventMethod_RecordEventAgainstViewKey()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetRequiresConsent(true);
@@ -497,32 +499,32 @@ namespace Assets.Tests.PlayModeTests
             //[CLY]_view
             Countly.Instance.Consents.GiveConsent(new Consents[] { Consents.Views });
 
-            await Countly.Instance.Events.RecordEventAsync("event");
+            yield return Countly.Instance.Events.RecordEventAsync("event").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_push_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_nps").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_orientation");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_orientation").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_survey");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_survey").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_view");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_view").AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_view", segmentation: null, count: 5, duration: null, sum: 1);
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_view", segmentation: null, count: 5, duration: null, sum: 1).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
@@ -532,8 +534,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates 'recordEvent' against action specific key '[CLY]_action'.
         /// </summary>
-        [Test]
-        public async void TestEventMethod_RecordEventAgainstActionKey()
+        [UnityTest]
+        public IEnumerator TestEventMethod_RecordEventAgainstActionKey()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetRequiresConsent(true);
@@ -545,34 +547,34 @@ namespace Assets.Tests.PlayModeTests
 
             Countly.Instance.Consents.GiveConsent(new Consents[] { Consents.Clicks });
 
-            await Countly.Instance.Events.RecordEventAsync("event");
+            yield return Countly.Instance.Events.RecordEventAsync("event").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_push_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_nps").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_orientation");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_orientation").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_survey");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_survey").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_view");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_view").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_action").AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_action", 0, 1, null, null);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_action", segmentation: null, count: 5, duration: null, sum: 1);
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_action", segmentation: null, count: 5, duration: null, sum: 1).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
@@ -582,8 +584,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates 'recordEvent' against action specific key '[CLY]_star_rating'.
         /// </summary>
-        [Test]
-        public async void TestEventMethod_RecordEventAgainstStarRatingKey()
+        [UnityTest]
+        public IEnumerator TestEventMethod_RecordEventAgainstStarRatingKey()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetRequiresConsent(true);
@@ -595,34 +597,34 @@ namespace Assets.Tests.PlayModeTests
 
             Countly.Instance.Consents.GiveConsent(new Consents[] { Consents.StarRating });
 
-            await Countly.Instance.Events.RecordEventAsync("event");
+            yield return Countly.Instance.Events.RecordEventAsync("event").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_push_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_nps").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_orientation");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_orientation").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_survey");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_survey").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_view");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_view").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating").AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_star_rating", 0, 1, null, null);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating", segmentation: null, count: 5, duration: null, sum: 1);
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating", segmentation: null, count: 5, duration: null, sum: 1).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
@@ -632,8 +634,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates 'recordEvent' against push specific key '[CLY]_push_action'.
         /// </summary>
-        [Test]
-        public async void TestEventMethod_RecordEventAgainstPushActionKey()
+        [UnityTest]
+        public IEnumerator TestEventMethod_RecordEventAgainstPushActionKey()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetRequiresConsent(true);
@@ -646,34 +648,34 @@ namespace Assets.Tests.PlayModeTests
             //[CLY]_push_action
             Countly.Instance.Consents.GiveConsent(new Consents[] { Consents.Push });
 
-            await Countly.Instance.Events.RecordEventAsync("event");
+            yield return Countly.Instance.Events.RecordEventAsync("event").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_nps").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_orientation");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_orientation").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_survey");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_survey").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_view");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_view").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_push_action").AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_push_action", 0, 1, null, null);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action", segmentation: null, count: 5, duration: null, sum: 1);
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_push_action", segmentation: null, count: 5, duration: null, sum: 1).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
@@ -683,8 +685,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates 'recordEvent' against push specific key '[CLY]_orientation'.
         /// </summary>
-        [Test]
-        public async void TestEventMethod_RecordEventAgainstOrientationKey()
+        [UnityTest]
+        public IEnumerator TestEventMethod_RecordEventAgainstOrientationKey()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetRequiresConsent(true);
@@ -696,34 +698,34 @@ namespace Assets.Tests.PlayModeTests
 
             Countly.Instance.Consents.GiveConsent(new Consents[] { Consents.Users });
 
-            await Countly.Instance.Events.RecordEventAsync("event");
+            yield return Countly.Instance.Events.RecordEventAsync("event").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_view");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_view").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_Push_Action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_Push_Action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_push_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_survey");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_survey").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_orientation");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_orientation").AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_orientation", 0, 1, null, null);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_orientation", segmentation: null, count: 5, duration: null, sum: 1);
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_orientation", segmentation: null, count: 5, duration: null, sum: 1).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
@@ -733,8 +735,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates 'recordEvent' against nps([CLY]_nps) and survey([CLY]_survey) specific keys.
         /// </summary>
-        [Test]
-        public async void TestEventMethod_RecordEventAsyncWithSpecificKeys()
+        [UnityTest]
+        public IEnumerator TestEventMethod_RecordEventAsyncWithSpecificKeys()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetRequiresConsent(true);
@@ -746,28 +748,28 @@ namespace Assets.Tests.PlayModeTests
 
             Countly.Instance.Consents.GiveConsent(new Consents[] { Consents.Feedback });
 
-            await Countly.Instance.Events.RecordEventAsync("event");
+            yield return Countly.Instance.Events.RecordEventAsync("event").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_view");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_view").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_Push_Action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_Push_Action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_push_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_orientation");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_orientation").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_survey");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_survey").AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
@@ -778,19 +780,19 @@ namespace Assets.Tests.PlayModeTests
             Assert.IsNull(model.Duration);
             Assert.IsNull(model.Segmentation);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_survey", segmentation: null, count: 5, duration: null, sum: 1);
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_survey", segmentation: null, count: 5, duration: null, sum: 1).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_survey", 1, 5, null, null);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_nps").AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
             AssertAnEvent(model, "[CLY]_nps", 0, 1, null, null);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_nps", segmentation: null, count: 5, duration: null, sum: 1);
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_nps", segmentation: null, count: 5, duration: null, sum: 1).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();
@@ -800,8 +802,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates 'recordEvent' against specific event keys.
         /// </summary>
-        [Test]
-        public async void TestEventMethod_RecordEventAgainstSpecificEventKeys()
+        [UnityTest]
+        public IEnumerator TestEventMethod_RecordEventAgainstSpecificEventKeys()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetRequiresConsent(true);
@@ -813,28 +815,28 @@ namespace Assets.Tests.PlayModeTests
 
             Countly.Instance.Consents.GiveConsent(new Consents[] { Consents.Events });
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_view");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_view").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_nps");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_nps").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_survey");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_survey").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_orientation");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_orientation").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_star_rating").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("[CLY]_push_action");
+            yield return Countly.Instance.Events.RecordEventAsync("[CLY]_push_action").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.Events._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("event");
+            yield return Countly.Instance.Events.RecordEventAsync("event").AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             CountlyEventModel model = Countly.Instance.Events._eventRepo.Dequeue();
@@ -845,7 +847,7 @@ namespace Assets.Tests.PlayModeTests
             Assert.IsNull(model.Duration);
             Assert.IsNull(model.Segmentation);
 
-            await Countly.Instance.Events.RecordEventAsync("event", segmentation: null, count: 5, duration: null, sum: 1);
+            yield return Countly.Instance.Events.RecordEventAsync("event", segmentation: null, count: 5, duration: null, sum: 1).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.Events._eventRepo.Count);
 
             model = Countly.Instance.Events._eventRepo.Dequeue();

--- a/Assets/Tests/PlayModeTests/Legacy Tests/UserCustomDetailsTests.cs
+++ b/Assets/Tests/PlayModeTests/Legacy Tests/UserCustomDetailsTests.cs
@@ -4,6 +4,9 @@ using System.Web;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Plugins.CountlySDK;
+using UnityEngine.TestTools;
+using System.Collections;
+using System.Threading.Tasks;
 using Plugins.CountlySDK.Models;
 
 namespace Assets.Tests.PlayModeTests.LegacyTests
@@ -35,8 +38,8 @@ namespace Assets.Tests.PlayModeTests.LegacyTests
         // 'SetUserDetailsAsync' method in Countly.Instance.UserDetails
         // We call the method first with a null value then a valid user details value
         // Null value shouldn't record anything, valid values should be recorded correctly
-        [Test]
-        public async void SetUserDetailsAsync()
+        [UnityTest]
+        public IEnumerator SetUserDetailsAsync()
         {
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Assert.IsNotNull(Countly.Instance.UserDetails);
@@ -46,7 +49,7 @@ namespace Assets.Tests.PlayModeTests.LegacyTests
 
             CountlyUserDetailsModel userDetails = null;
 
-            await Countly.Instance.UserDetails.SetUserDetailsAsync(userDetails);
+            yield return Countly.Instance.UserDetails.SetUserDetailsAsync(userDetails).AsCoroutine();
             TestUtility.ValidateRQEQSize(Countly.Instance, 0, 0);
 
             userDetails = new CountlyUserDetailsModel("Full Name", "username", "useremail@email.com", "Organization",
@@ -57,7 +60,7 @@ namespace Assets.Tests.PlayModeTests.LegacyTests
                         { "Hair", "Black" },
                         { "Height", "5.9" },
                     });
-            await Countly.Instance.UserDetails.SetUserDetailsAsync(userDetails);
+            yield return Countly.Instance.UserDetails.SetUserDetailsAsync(userDetails).AsCoroutine();
 
             TestUtility.ValidateRQEQSize(Countly.Instance, 1, 0);
             CountlyRequestModel requestModel = Countly.Instance.RequestHelper._requestRepo.Dequeue();
@@ -69,10 +72,16 @@ namespace Assets.Tests.PlayModeTests.LegacyTests
         // 'SetUserDetailAsync' method in Countly.Instance.UserDetails
         // We pass invalid URLs to the user profiles property as null, empty and non url string
         // Nothing should break and picture url should be recorded
-        [TestCase("Invalid URL", "Invalid URL")]
-        [TestCase(null, null)]
-        [TestCase("", "")]
-        public async void SetPicturePath(string setPictureUrl, string expectedValue)
+        [UnityTest]
+        public IEnumerator SetPicturePath_InvalidUrl() { yield return SetPicturePathImpl("Invalid URL", "Invalid URL"); }
+
+        [UnityTest]
+        public IEnumerator SetPicturePath_Null() { yield return SetPicturePathImpl(null, null); }
+
+        [UnityTest]
+        public IEnumerator SetPicturePath_Empty() { yield return SetPicturePathImpl("", ""); }
+
+        private IEnumerator SetPicturePathImpl(string setPictureUrl, string expectedValue)
         {
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
             Countly.Instance.RequestHelper._requestRepo.Clear();
@@ -83,7 +92,7 @@ namespace Assets.Tests.PlayModeTests.LegacyTests
 
             // Attempt to set user details with a null user model
             CountlyUserDetailsModel userDetails = null;
-            await Countly.Instance.UserDetails.SetUserDetailsAsync(userDetails);
+            yield return Countly.Instance.UserDetails.SetUserDetailsAsync(userDetails).AsCoroutine();
             TestUtility.ValidateRQEQSize(Countly.Instance, 0, 0);
 
             // Initialize userDetails and assign an invalid picture URL to the user model
@@ -95,7 +104,7 @@ namespace Assets.Tests.PlayModeTests.LegacyTests
                         { "Song", "Billie Jean" },
                         { "Team", "Arsenal" },
                     });
-            await Countly.Instance.UserDetails.SetUserDetailsAsync(userDetails);
+            yield return Countly.Instance.UserDetails.SetUserDetailsAsync(userDetails).AsCoroutine();
 
             // Ensure that a request is added, retrieve and parse it for verification
             TestUtility.ValidateRQEQSize(Countly.Instance, 1, 0);
@@ -115,8 +124,8 @@ namespace Assets.Tests.PlayModeTests.LegacyTests
         // 'SetUserDetailAsync' method in Countly.Instance.UserDetails
         // We check configuration limits for user profile fields
         // Nothing should break and values should be recorded within limits
-        [Test]
-        public async void TestUserProfileFieldsLimits()
+        [UnityTest]
+        public IEnumerator TestUserProfileFieldsLimits()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetMaxValueSize(3);
@@ -129,7 +138,7 @@ namespace Assets.Tests.PlayModeTests.LegacyTests
 
             CountlyUserDetailsModel userDetails = null;
 
-            await Countly.Instance.UserDetails.SetUserDetailsAsync(userDetails);
+            yield return Countly.Instance.UserDetails.SetUserDetailsAsync(userDetails).AsCoroutine();
             TestUtility.ValidateRQEQSize(Countly.Instance, 0, 0);
             
             userDetails = new CountlyUserDetailsModel("Full Name", "username", "useremail@email.com", "Organization",
@@ -145,7 +154,7 @@ namespace Assets.Tests.PlayModeTests.LegacyTests
                         { "Hair", "Black" },
                         { "Height", "5.9" },
                     });
-            await Countly.Instance.UserDetails.SetUserDetailsAsync(userDetails);
+            yield return Countly.Instance.UserDetails.SetUserDetailsAsync(userDetails).AsCoroutine();
             TestUtility.ValidateRQEQSize(Countly.Instance, 1, 0);
             
             CountlyRequestModel requestModel = Countly.Instance.RequestHelper._requestRepo.Dequeue();
@@ -306,8 +315,8 @@ namespace Assets.Tests.PlayModeTests.LegacyTests
         // User detail methods in Countly.Instance.UserDetails
         // We validate custom user detail methods with invalid keys
         // Nothing should be recorded and nothing should break
-        [Test]
-        public async void CustomUserDetailInvalidKeys()
+        [UnityTest]
+        public IEnumerator CustomUserDetailInvalidKeys()
         {
             CountlyConfiguration configuration = TestUtility.CreateBaseConfig()
                 .SetMaxKeyLength(5)
@@ -342,7 +351,7 @@ namespace Assets.Tests.PlayModeTests.LegacyTests
             Countly.Instance.UserDetails.Max(null, 10000.0);
             Countly.Instance.UserDetails.Multiply(null, 10.0);
 
-            await Countly.Instance.UserDetails.SaveAsync();
+            yield return Countly.Instance.UserDetails.SaveAsync().AsCoroutine();
             TestUtility.ValidateRQEQSize(Countly.Instance, 0, 0);
         }
 
@@ -459,8 +468,8 @@ namespace Assets.Tests.PlayModeTests.LegacyTests
         // 'SaveAsync' method in Countly.Instance.UserDetails
         // We validate the user's custom properties before and after calling 'SaveAsync'.
         // Nothing should break, values should be recorded correctly
-        [Test]
-        public async void UserDetailService_SaveAsync()
+        [UnityTest]
+        public IEnumerator UserDetailService_SaveAsync()
         {
             // Initialize, ensure that the UserDetails instance is not null and request repository is empty
             Countly.Instance.Init(TestUtility.CreateBaseConfig());
@@ -478,7 +487,7 @@ namespace Assets.Tests.PlayModeTests.LegacyTests
             Dictionary<string, object> dic2 = Countly.Instance.UserDetails.RetrieveCustomDataValue("Age") as Dictionary<string, object>;
             Assert.AreEqual(new string[] { "29" }, dic2["$push"]);
 
-            await Countly.Instance.UserDetails.SaveAsync();
+            yield return Countly.Instance.UserDetails.SaveAsync().AsCoroutine();
 
             Assert.AreEqual(false, Countly.Instance.UserDetails.ContainsCustomDataKey("Age"));
             Assert.AreEqual(false, Countly.Instance.UserDetails.ContainsCustomDataKey("Distance"));

--- a/Assets/Tests/PlayModeTests/SessionTests.cs
+++ b/Assets/Tests/PlayModeTests/SessionTests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using Plugins.CountlySDK.Models;
 using Plugins.CountlySDK;
+using System.Threading.Tasks;
 using System.Web;
 using System.Collections.Specialized;
 using Newtonsoft.Json.Linq;
@@ -51,21 +52,21 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It checks the working of session service if no 'Session' consent is given.
         /// </summary>
-        [Test]
-        public async void SessionConsent()
+        [UnityTest]
+        public IEnumerator SessionConsent()
         {
             Countly.Instance.Init(TestUtility.CreateBaseConfigConsent(null));
             Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Clear();
             Assert.IsNotNull(Countly.Instance.Session);
             Assert.AreEqual(0, Countly.Instance.Session._requestCountlyHelper._requestRepo.Count);
 
-            await Countly.Instance.Session.BeginSessionAsync();
+            yield return Countly.Instance.Session.BeginSessionAsync().AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
 
-            await Countly.Instance.Session.ExtendSessionAsync();
+            yield return Countly.Instance.Session.ExtendSessionAsync().AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
 
-            await Countly.Instance.Session.EndSessionAsync();
+            yield return Countly.Instance.Session.EndSessionAsync().AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Count);
         }
 

--- a/Assets/Tests/PlayModeTests/StarRatingTests.cs
+++ b/Assets/Tests/PlayModeTests/StarRatingTests.cs
@@ -2,6 +2,9 @@
 using UnityEngine;
 using Plugins.CountlySDK.Models;
 using Plugins.CountlySDK;
+using UnityEngine.TestTools;
+using System.Collections;
+using System.Threading.Tasks;
 using Plugins.CountlySDK.Enums;
 using System.Collections.Generic;
 
@@ -46,8 +49,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates the dependency of 'Event Consent' on StarRating Service.
         /// </summary>
-        [Test]
-        public async void TestStarRating_CheckEventConsentDependency()
+        [UnityTest]
+        public IEnumerator TestStarRating_CheckEventConsentDependency()
         {
             CountlyConfiguration configuration = new CountlyConfiguration {
                 ServerUrl = _serverUrl,
@@ -65,7 +68,7 @@ namespace Assets.Tests.PlayModeTests
             Assert.IsNotNull(Countly.Instance.StarRating);
             Assert.AreEqual(0, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
-            await Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 3);
+            yield return Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 3).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
             CountlyEventModel model = Countly.Instance.StarRating._eventCountlyService._eventRepo.Dequeue();
@@ -81,8 +84,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It checks the working of StarRating service if no StarRating consent is given.
         /// </summary>
-        [Test]
-        public async void TestStarRatingConsent()
+        [UnityTest]
+        public IEnumerator TestStarRatingConsent()
         {
             CountlyConfiguration configuration = new CountlyConfiguration {
                 ServerUrl = _serverUrl,
@@ -99,15 +102,15 @@ namespace Assets.Tests.PlayModeTests
             Assert.IsNotNull(Countly.Instance.StarRating);
             Assert.AreEqual(0, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
-            await Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 3);
+            yield return Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 3).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
         }
 
         /// <summary>
         /// It validates functionality of method 'ReportStarRatingAsync'.
         /// </summary>
-        [Test]
-        public async void TestStarRatingMethod_ReportStarRatingAsync()
+        [UnityTest]
+        public IEnumerator TestStarRatingMethod_ReportStarRatingAsync()
         {
             CountlyConfiguration configuration = new CountlyConfiguration {
                 ServerUrl = _serverUrl,
@@ -120,7 +123,7 @@ namespace Assets.Tests.PlayModeTests
             Countly.Instance.CrashReports._requestCountlyHelper._requestRepo.Clear();
 
             Assert.IsNotNull(Countly.Instance.StarRating);
-            await Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 5);
+            yield return Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 5).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
             CountlyEventModel model = Countly.Instance.StarRating._eventCountlyService._eventRepo.Dequeue();
@@ -146,8 +149,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates the parameters of 'ReportStarRatingAsync' method.
         /// </summary>
-        [Test]
-        public async void TestStarRating_ValidatesParams()
+        [UnityTest]
+        public IEnumerator TestStarRating_ValidatesParams()
         {
             CountlyConfiguration configuration = new CountlyConfiguration {
                 ServerUrl = _serverUrl,
@@ -162,25 +165,25 @@ namespace Assets.Tests.PlayModeTests
             Assert.AreEqual(0, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
 
-            await Countly.Instance.StarRating.ReportStarRatingAsync("", "0.1", 4);
+            yield return Countly.Instance.StarRating.ReportStarRatingAsync("", "0.1", 4).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
-            await Countly.Instance.StarRating.ReportStarRatingAsync(null, "0.1", 4);
+            yield return Countly.Instance.StarRating.ReportStarRatingAsync(null, "0.1", 4).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
-            await Countly.Instance.StarRating.ReportStarRatingAsync("android", "", 4);
+            yield return Countly.Instance.StarRating.ReportStarRatingAsync("android", "", 4).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
-            await Countly.Instance.StarRating.ReportStarRatingAsync("android", null, 4);
+            yield return Countly.Instance.StarRating.ReportStarRatingAsync("android", null, 4).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
-            await Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 0);
+            yield return Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 0).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
-            await Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 6);
+            yield return Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 6).AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
-            await Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 4);
+            yield return Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 4).AsCoroutine();
             Assert.AreEqual(1, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
         }
@@ -188,8 +191,8 @@ namespace Assets.Tests.PlayModeTests
         /// <summary>
         /// It validates 'EventQueueThreshold' limit.
         /// </summary>
-        [Test]
-        public async void TestStarRating_EventQueueThreshold_Limit()
+        [UnityTest]
+        public IEnumerator TestStarRating_EventQueueThreshold_Limit()
         {
             CountlyConfiguration configuration = new CountlyConfiguration {
                 ServerUrl = _serverUrl,
@@ -207,10 +210,10 @@ namespace Assets.Tests.PlayModeTests
             Countly.Instance.Views.StartView("view");
             Assert.AreEqual(1, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
-            await Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 4);
+            yield return Countly.Instance.StarRating.ReportStarRatingAsync("android", "0.1", 4).AsCoroutine();
             Assert.AreEqual(2, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
 
-            await Countly.Instance.Events.RecordEventAsync("test_event");
+            yield return Countly.Instance.Events.RecordEventAsync("test_event").AsCoroutine();
             Assert.AreEqual(0, Countly.Instance.StarRating._eventCountlyService._eventRepo.Count);
         }
 

--- a/Assets/Tests/PlayModeTests/TaskCoroutineExtensions.cs
+++ b/Assets/Tests/PlayModeTests/TaskCoroutineExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+
+namespace Assets.Tests.PlayModeTests
+{
+    /// <summary>
+    /// Bridges Task-returning async SDK calls into Unity coroutines so the same
+    /// [UnityTest] tests run on every supported Unity / Test Framework version
+    /// (2020.3 LTS through Unity 6). Neither 'async void' nor 'async Task' [Test]
+    /// methods are accepted by both editor lines, but [UnityTest] IEnumerator is.
+    /// </summary>
+    public static class TaskCoroutineExtensions
+    {
+        /// <summary>
+        /// Yields each frame until the task completes, then rethrows the original
+        /// exception (preserving its stack) if the task faulted.
+        /// </summary>
+        public static IEnumerator AsCoroutine(this Task task)
+        {
+            while (!task.IsCompleted) {
+                yield return null;
+            }
+
+            if (task.IsFaulted) {
+                Exception ex = (task.Exception != null && task.Exception.InnerExceptions.Count == 1)
+                    ? task.Exception.InnerException
+                    : task.Exception;
+                ExceptionDispatchInfo.Capture(ex).Throw();
+            }
+        }
+    }
+}

--- a/Assets/Tests/PlayModeTests/TaskCoroutineExtensions.cs.meta
+++ b/Assets/Tests/PlayModeTests/TaskCoroutineExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c86b18369eeb4d80b30faf0e4cf5d080
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/PlayModeTests/ViewsTests.cs
+++ b/Assets/Tests/PlayModeTests/ViewsTests.cs
@@ -3,6 +3,9 @@ using NUnit.Framework;
 using UnityEngine;
 using Plugins.CountlySDK.Models;
 using Plugins.CountlySDK;
+using UnityEngine.TestTools;
+using System.Collections;
+using System.Threading.Tasks;
 using Plugins.CountlySDK.Enums;
 using Plugins.CountlySDK.Services;
 using System.Threading;
@@ -35,8 +38,8 @@ namespace Assets.Tests.PlayModeTests
         // 'RecordOpenViewAsync' method in ViewCountlyService
         // Validating how Views Service performs if no "views" consent is given.
         // If no consent is given, Views Service shouldn't record anything
-        [Test]
-        public async void ViewsConsent()
+        [UnityTest]
+        public IEnumerator ViewsConsent()
         {
             CountlyConfiguration config = TestUtility.CreateNoConsentConfig();
             Countly cly = Countly.Instance;
@@ -44,41 +47,41 @@ namespace Assets.Tests.PlayModeTests
             cly.Init(config);
             TestUtility.ValidateRQEQSize(cly, 2, 0);
 
-            await cly.Views.RecordOpenViewAsync(viewNames[0]);
+            yield return cly.Views.RecordOpenViewAsync(viewNames[0]).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 2, 0);
 
-            await cly.Views.RecordCloseViewAsync(viewNames[0]);
+            yield return cly.Views.RecordCloseViewAsync(viewNames[0]).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 2, 0);
         }
 
         // 'RecordCloseViewAsync' method in ViewCountlyService.
         // We try to close a view that's not existing
         // If view does not exist nothing should be recorded, nothing should crash
-        [Test]
-        public async void RecordCloseViewAsync_NoOpenView()
+        [UnityTest]
+        public IEnumerator RecordCloseViewAsync_NoOpenView()
         {
             CountlyConfiguration config = TestUtility.CreateViewConfig(new CustomIdProvider());
             Countly cly = Countly.Instance;
             cly.Init(config);
 
             TestUtility.ValidateRQEQSize(cly, 2, 0);
-            await cly.Views.RecordCloseViewAsync(viewNames[0]);
+            yield return cly.Views.RecordCloseViewAsync(viewNames[0]).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 2, 0);
         }
 
         // 'RecordCloseViewAsync' method in ViewCountlyService. 
         // Close a view, verify that the event is correctly recorded in the Views repository
         // If a null view name is provided, it shouldn't be recorded. 
-        [Test]
-        public async void RecordCloseViewAsync_NullAndEmptyViewName()
+        [UnityTest]
+        public IEnumerator RecordCloseViewAsync_NullAndEmptyViewName()
         {
             CountlyConfiguration config = TestUtility.CreateViewConfig(new CustomIdProvider());
             Countly cly = Countly.Instance;
             cly.Init(config);
             TestUtility.ValidateRQEQSize(cly, 2, 0);
 
-            await cly.Views.RecordCloseViewAsync(null);
-            await cly.Views.RecordCloseViewAsync("");
+            yield return cly.Views.RecordCloseViewAsync(null).AsCoroutine();
+            yield return cly.Views.RecordCloseViewAsync("").AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 2, 0);
         }
 
@@ -86,16 +89,16 @@ namespace Assets.Tests.PlayModeTests
         // Open a view and verify that the event is correctly recorded in the Views repository
         // If a valid view name is provided, it should be recorded and EventModel should be validated
         // It's possible to open 2 views at the same time
-        [Test]
-        public async void RecordOpenViewAsync()
+        [UnityTest]
+        public IEnumerator RecordOpenViewAsync()
         {
             CountlyConfiguration config = TestUtility.CreateViewConfig(new CustomIdProvider());
             Countly cly = Countly.Instance;
             cly.Init(config);
 
             TestUtility.ValidateRQEQSize(cly, 2, 0);
-            await cly.Views.RecordOpenViewAsync(viewNames[0]);
-            await cly.Views.RecordCloseViewAsync(viewNames[1]);
+            yield return cly.Views.RecordOpenViewAsync(viewNames[0]).AsCoroutine();
+            yield return cly.Views.RecordCloseViewAsync(viewNames[1]).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 2, 1);
 
             CountlyEventModel model = cly.Events._eventRepo.Dequeue();
@@ -105,24 +108,24 @@ namespace Assets.Tests.PlayModeTests
         // 'RecordOpenViewAsync' method in ViewCountlyService.
         // Open a view and verify that the event is correctly recorded in the Views repository
         // If an null view name is provided, it shouldn't be recorded. 
-        [Test]
-        public async void RecordOpenViewAsync_NullAndEmptyViewName()
+        [UnityTest]
+        public IEnumerator RecordOpenViewAsync_NullAndEmptyViewName()
         {
             CountlyConfiguration config = TestUtility.CreateViewConfig(new CustomIdProvider());
             Countly cly = Countly.Instance;
             cly.Init(config);
             TestUtility.ValidateRQEQSize(cly, 2, 0);
 
-            await cly.Views.RecordOpenViewAsync(null);
-            await cly.Views.RecordOpenViewAsync("");
+            yield return cly.Views.RecordOpenViewAsync(null).AsCoroutine();
+            yield return cly.Views.RecordOpenViewAsync("").AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 2, 0);
         }
 
         // 'RecordOpenViewAsync' method in ViewCountlyService.
         // Open a view with segmentation  and verify that verifies the event is correctly recorded in the Views repository 
         // If a valid view name and segmentation is provided, it should be recorded and EventModel should be validated
-        [Test]
-        public async void RecordOpenViewAsyncWithSegment()
+        [UnityTest]
+        public IEnumerator RecordOpenViewAsyncWithSegment()
         {
             CountlyConfiguration config = TestUtility.CreateViewConfig(new CustomIdProvider());
             Countly cly = Countly.Instance;
@@ -140,7 +143,7 @@ namespace Assets.Tests.PlayModeTests
                 { "key1", "value1" },
             };
 
-            await Countly.Instance.Views.RecordOpenViewAsync(viewNames[0], providedSegmentations);
+            yield return Countly.Instance.Views.RecordOpenViewAsync(viewNames[0], providedSegmentations).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 2, 1);
             CountlyEventModel model = cly.Events._eventRepo.Dequeue();
             TestUtility.ViewEventValidator(model, 1, 0, null, expectedSegmentations, "idv1", "", null, null, TestUtility.TestTimeMetrics());
@@ -149,7 +152,7 @@ namespace Assets.Tests.PlayModeTests
             Assert.IsFalse(model.Segmentation.ContainsKey("key2"));
             Assert.IsFalse(model.Segmentation.ContainsKey(""));
 
-            await Countly.Instance.Views.RecordOpenViewAsync(viewNames[1]);
+            yield return Countly.Instance.Views.RecordOpenViewAsync(viewNames[1]).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 2, 1);
             model = cly.Events._eventRepo.Dequeue();
             TestUtility.ViewEventValidator(model, 1, 0, null, TestUtility.BaseViewTestSegmentation(viewNames[1], false, false), "idv2", "idv1", null, null, TestUtility.TestTimeMetrics());
@@ -158,8 +161,8 @@ namespace Assets.Tests.PlayModeTests
         // 'RecordOpenViewAsync' method in ViewCountlyService.
         // We set an EventQueueThreshold limit before initialization and add events.
         // Once we reach the treshold, all events in the EQ should be written out to the RQ
-        [Test]
-        public async void EventQueueThreshold_Limit()
+        [UnityTest]
+        public IEnumerator EventQueueThreshold_Limit()
         {
             CountlyConfiguration config = TestUtility.CreateViewConfig(new CustomIdProvider())
                 .SetEventQueueSizeToSend(1);
@@ -167,19 +170,19 @@ namespace Assets.Tests.PlayModeTests
             cly.Init(config);
 
             TestUtility.ValidateRQEQSize(cly, 2, 0);
-            await Countly.Instance.Views.RecordOpenViewAsync(viewNames[0]);
+            yield return Countly.Instance.Views.RecordOpenViewAsync(viewNames[0]).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 3, 0);
-            await Countly.Instance.Views.RecordCloseViewAsync(viewNames[0]);
+            yield return Countly.Instance.Views.RecordCloseViewAsync(viewNames[0]).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 4, 0);
-            await Countly.Instance.Views.ReportActionAsync("action", 10, 10, 100, 100);
+            yield return Countly.Instance.Views.ReportActionAsync("action", 10, 10, 100, 100).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 5, 0);
         }
 
         // 'ReportActionAsync' method in ViewCountlyService.
         // We report a particular action with the specified details
         // The action should be recorded and its fields are validated.
-        [Test]
-        public async void ReportActionAsync()
+        [UnityTest]
+        public IEnumerator ReportActionAsync()
         {
             CountlyConfiguration config = TestUtility.CreateViewConfig(new CustomIdProvider());
             Countly cly = Countly.Instance;
@@ -194,7 +197,7 @@ namespace Assets.Tests.PlayModeTests
                 { "height", 100 }
             };
 
-            await Countly.Instance.Views.ReportActionAsync("action", 10, 20, 100, 100);
+            yield return Countly.Instance.Views.ReportActionAsync("action", 10, 20, 100, 100).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 2, 1);
             CountlyEventModel model = cly.Events._eventRepo.Dequeue();
             TestUtility.ViewEventValidator(model, 1, null, null, action, null, null, null, null, TestUtility.TestTimeMetrics(), true);
@@ -209,23 +212,23 @@ namespace Assets.Tests.PlayModeTests
         // 'RecordOpenViewAsync' method in ViewCountlyService and 'ChangeDeviceIdWithoutMerge' method in DeviceIdCountlyService.
         // We validate the behavior of the "isFirstView" and view event recording after changing the device ID without merging
         // When a view is started afterwards, it should be count as first view
-        [Test]
-        public async void StartField_AfterDeviceIdChangeWithoutMerge()
+        [UnityTest]
+        public IEnumerator StartField_AfterDeviceIdChangeWithoutMerge()
         {
             CountlyConfiguration config = TestUtility.CreateViewConfig(new CustomIdProvider());
             Countly cly = Countly.Instance;
             cly.Init(config);
             TestUtility.ValidateRQEQSize(cly, 2, 0);
 
-            await Countly.Instance.Views.RecordOpenViewAsync(viewNames[0]);
+            yield return Countly.Instance.Views.RecordOpenViewAsync(viewNames[0]).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 2, 1);
             CountlyEventModel model = cly.Events._eventRepo.Dequeue();
             TestUtility.ViewEventValidator(model, 1, 0, null, TestUtility.BaseViewTestSegmentation(viewNames[0], true, true), "idv1", "", null, null, TestUtility.TestTimeMetrics());
 
-            await Countly.Instance.Device.ChangeDeviceIdWithoutMerge("new device id");
+            yield return Countly.Instance.Device.ChangeDeviceIdWithoutMerge("new device id").AsCoroutine();
             Countly.Instance.Consents.GiveConsentAll();
 
-            await Countly.Instance.Views.RecordOpenViewAsync(viewNames[1]);
+            yield return Countly.Instance.Views.RecordOpenViewAsync(viewNames[1]).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 4, 1);
             CountlyEventModel secondModel = cly.Events._eventRepo.Dequeue();
             // BaseViewTestSegmentation(string viewName, bool isVisit, bool isStart) passing true in here means that this is first view
@@ -233,12 +236,12 @@ namespace Assets.Tests.PlayModeTests
 
             Thread.Sleep(1000);
 
-            await Countly.Instance.Views.RecordCloseViewAsync(viewNames[0]);
+            yield return Countly.Instance.Views.RecordCloseViewAsync(viewNames[0]).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 4, 1);
             CountlyEventModel resultStop = cly.Events._eventRepo.Dequeue();
             TestUtility.ViewEventValidator(resultStop, 1, 0, 1, TestUtility.BaseViewTestSegmentation(viewNames[0], false, false), "idv1", "idv1", null, null, TestUtility.TestTimeMetrics());
 
-            await Countly.Instance.Views.RecordCloseViewAsync(viewNames[1]);
+            yield return Countly.Instance.Views.RecordCloseViewAsync(viewNames[1]).AsCoroutine();
             TestUtility.ValidateRQEQSize(cly, 4, 1);
             CountlyEventModel resultStop2 = cly.Events._eventRepo.Dequeue();
             TestUtility.ViewEventValidator(resultStop2, 1, 0, 1, TestUtility.BaseViewTestSegmentation(viewNames[1], false, false), "idv2", "idv1", null, null, TestUtility.TestTimeMetrics());


### PR DESCRIPTION
2020.3 rejects 'async Task' while Unity 6.x rejects 'async void' . IEnumerator is works fine in both